### PR TITLE
Astro v5 project scaffold with GitHub Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build with Astro
+        uses: withastro/action@v6
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://how-do-i.ai',
+  output: 'static',
+  build: {
+    format: 'directory',
+  },
+});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>How Do I AI</title>
+  </head>
+  <body>
+    <h1>How Do I AI</h1>
+  </body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## Summary
- Initialize Astro v5 project with `output: 'static'` and `build.format: 'directory'`
- Configure `site: 'https://how-do-i.ai'` in astro.config.mjs
- Add GitHub Actions deploy workflow using `withastro/action@v6` and `actions/deploy-pages@v5`
- Add TypeScript strict config, `.nojekyll`, and minimal index page

## Test plan
- [x] `npm run build` produces static output in `dist/`
- [ ] GitHub Actions workflow triggers on push to `main`
- [ ] Site deploys to GitHub Pages at https://how-do-i.ai

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)