### PR TITLE
(feat) layout shell: BaseHead, BaseLayout, Nav, Footer

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,0 +1,48 @@
+---
+interface Props {
+  title: string;
+  description: string;
+}
+
+const { title, description } = Astro.props;
+---
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content={description} />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+  <!-- Font preloads -->
+  <link
+    rel="preload"
+    href="/fonts/InterVariable.woff2"
+    as="font"
+    type="font/woff2"
+    crossorigin
+  />
+  <link
+    rel="preload"
+    href="/fonts/JetBrainsMono-Regular.woff2"
+    as="font"
+    type="font/woff2"
+    crossorigin
+  />
+
+  <!-- Global styles -->
+  <style>
+    @import '../styles/global.css';
+  </style>
+
+  <!-- Inline dark mode script: prevent flash of wrong theme -->
+  <script is:inline>
+    (function () {
+      var t = localStorage.getItem('theme');
+      if (t === 'dark' || (!t && matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+
+  <title>{title}</title>
+</head>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,64 @@
+---
+---
+
+<footer class="site-footer">
+  <div class="footer-inner">
+    <p class="tagline">AI first. For all of it.</p>
+    <a href="/rss.xml" class="rss-link" aria-label="RSS Feed">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M4 11a9 9 0 0 1 9 9" />
+        <path d="M4 4a16 16 0 0 1 16 16" />
+        <circle cx="5" cy="19" r="1" />
+      </svg>
+      <span>RSS</span>
+    </a>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    border-top: 1px solid var(--color-surface);
+    padding: var(--space-8) var(--space-6);
+    margin-top: var(--space-16);
+  }
+
+  .footer-inner {
+    max-width: 64rem;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+  }
+
+  .tagline {
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+    margin: 0;
+  }
+
+  .rss-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .rss-link:hover {
+    color: var(--color-accent);
+  }
+</style>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,199 @@
+---
+import { getPostsByPillar } from '../lib/posts';
+
+interface Props {
+  activePillar?: string;
+}
+
+const { activePillar } = Astro.props;
+
+const btsPosts = await getPostsByPillar('behind-the-scenes');
+const showBts = btsPosts.length > 0;
+
+const pillars = [
+  { slug: 'ai-first-thinking', label: 'AI-First Thinking' },
+  { slug: 'ai-in-practice', label: 'AI in Practice' },
+  { slug: 'tools-and-workflows', label: 'Tools & Workflows' },
+];
+
+if (showBts) {
+  pillars.push({ slug: 'behind-the-scenes', label: 'Behind the Scenes' });
+}
+---
+
+<nav class="site-nav" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a href="/" class="wordmark" aria-label="How Do I AI home">
+      How Do I AI<span class="question-mark">?</span>
+    </a>
+
+    <div class="nav-links">
+      <ul class="pillar-links" role="list">
+        {pillars.map((pillar) => (
+          <li>
+            <a
+              href={`/blog/?pillar=${pillar.slug}`}
+              class:list={['pillar-link', { active: activePillar === pillar.slug }]}
+            >
+              {pillar.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <div class="nav-actions">
+        <!-- ThemeToggle placeholder (issue #5) -->
+        <div class="theme-toggle-placeholder" aria-hidden="true"></div>
+
+        <a href="/rss.xml" class="rss-icon-link" aria-label="RSS Feed">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M4 11a9 9 0 0 1 9 9" />
+            <path d="M4 4a16 16 0 0 1 16 16" />
+            <circle cx="5" cy="19" r="1" />
+          </svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<style>
+  .site-nav {
+    padding: var(--space-4) var(--space-6);
+    border-bottom: 1px solid var(--color-surface);
+  }
+
+  .nav-inner {
+    max-width: 64rem;
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .wordmark {
+    font-family: var(--font-sans);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    color: var(--color-text);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .wordmark:hover {
+    color: var(--color-text);
+  }
+
+  .question-mark {
+    color: var(--color-accent);
+  }
+
+  .nav-links {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-4);
+  }
+
+  .pillar-links {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    list-style: none;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .pillar-links::-webkit-scrollbar {
+    display: none;
+  }
+
+  .pillar-link {
+    display: inline-block;
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-lg);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-muted);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: color var(--transition-fast), background-color var(--transition-fast);
+  }
+
+  .pillar-link:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface);
+  }
+
+  .pillar-link.active {
+    color: var(--color-accent);
+    background-color: var(--color-surface);
+  }
+
+  .nav-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-shrink: 0;
+  }
+
+  .theme-toggle-placeholder {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .rss-icon-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-muted);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .rss-icon-link:hover {
+    color: var(--color-accent);
+  }
+
+  /* Mobile: stack wordmark above scrollable pillar chips */
+  @media (max-width: 767px) {
+    .nav-inner {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .wordmark {
+      text-align: center;
+    }
+
+    .nav-links {
+      justify-content: space-between;
+    }
+
+    .pillar-links {
+      flex: 1;
+      min-width: 0;
+    }
+  }
+
+  /* Desktop: wordmark left, links center-right, actions far right */
+  @media (min-width: 768px) {
+    .nav-inner {
+      flex-wrap: nowrap;
+    }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,48 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+
+interface Props {
+  title: string;
+  description: string;
+  activePillar?: string;
+}
+
+const { title, description, activePillar } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <BaseHead title={title} description={description} />
+  <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
+    <header>
+      <Nav activePillar={activePillar} />
+    </header>
+    <main id="main-content">
+      <slot />
+    </main>
+    <Footer />
+  </body>
+</html>
+
+<style>
+  .skip-link {
+    position: absolute;
+    left: -9999px;
+    top: var(--space-2);
+    z-index: 100;
+    padding: var(--space-2) var(--space-4);
+    background-color: var(--color-accent);
+    color: #fff;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    border-radius: var(--radius-md);
+    text-decoration: none;
+  }
+
+  .skip-link:focus {
+    left: var(--space-4);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,7 @@
 ---
-import '../styles/global.css';
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>How Do I AI</title>
-  </head>
-  <body>
-    <h1>How Do I AI</h1>
-  </body>
-</html>
+<BaseLayout title="How Do I AI" description="AI first. For all of it.">
+  <h1>How Do I AI</h1>
+</BaseLayout>


### PR DESCRIPTION
## Summary

- Add `BaseHead.astro` with charset, viewport, description meta, font preloads for Inter and JetBrains Mono, global.css import, and an inline dark mode script (~150 bytes) that reads `localStorage('theme')` then falls back to `prefers-color-scheme` to set `.dark` on `<html>` before paint
- Add `BaseLayout.astro` with `<html lang="en">`, skip-to-content link as first focusable element, `<header>` with Nav, `<main id="main-content">` with slot, and `<footer>` with Footer
- Add `Nav.astro` with wordmark ("How Do I AI" + Signal Orange "?"), pillar links (conditionally includes "Behind the Scenes" only when >= 1 published BTS post exists), ThemeToggle placeholder slot, and RSS icon link. Desktop: wordmark left, links center-right, RSS far right. Mobile: wordmark top, horizontally scrollable pillar chips below, no hamburger menu
- Add `Footer.astro` with tagline "AI first. For all of it." and RSS link
- Update `index.astro` to use `BaseLayout`

Closes #4

## Test plan

- [ ] `npm run build` succeeds
- [ ] Every page has `<html lang="en">`, skip-link, `<header>`, `<nav>`, `<main>`, `<footer>` landmarks
- [ ] Desktop (>= 768px): wordmark left, pillar links center-right, RSS far right
- [ ] Mobile (< 768px): pillar chips horizontally scrollable below wordmark, no hamburger
- [ ] With 0 BTS posts: only 3 pillar links render
- [ ] With 1+ BTS posts: all 4 pillar links render
- [ ] Active pillar link highlights when `activePillar` prop matches
- [ ] Dark mode script sets `.dark` class before paint (no flash)
- [ ] Skip-link is visually hidden but visible on focus
- [ ] Footer shows tagline and RSS link

🤖 Generated with [Claude Code](https://claude.com/claude-code)