### PR TITLE
Post card components

### DIFF
--- a/src/components/PillarBadge.astro
+++ b/src/components/PillarBadge.astro
@@ -1,0 +1,31 @@
+---
+interface Props {
+  pillar: string;
+}
+
+const PILLAR_LABELS: Record<string, string> = {
+  'ai-first-thinking': 'AI-First Thinking',
+  'ai-in-practice': 'AI in Practice',
+  'tools-and-workflows': 'Tools & Workflows',
+  'behind-the-scenes': 'Behind the Scenes',
+};
+
+const { pillar } = Astro.props;
+const label = PILLAR_LABELS[pillar] ?? pillar;
+---
+
+<span class="pillar-badge">{label}</span>
+
+<style>
+  .pillar-badge {
+    display: inline-block;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    line-height: 1;
+    color: var(--color-bg);
+    background-color: var(--color-accent);
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,0 +1,104 @@
+---
+import PillarBadge from './PillarBadge.astro';
+import SeriesBadge from './SeriesBadge.astro';
+import TagList from './TagList.astro';
+import { formatDate } from '../lib/format-date';
+import { estimateReadingTime } from '../lib/reading-time';
+
+interface Props {
+  post: {
+    id: string;
+    body?: string;
+    data: {
+      title: string;
+      description: string;
+      date: Date;
+      pillar: string;
+      series?: string;
+      tags: string[];
+      readingTime?: number;
+    };
+  };
+}
+
+const { post } = Astro.props;
+const { title, description, date, pillar, series, tags, readingTime } = post.data;
+
+const displayDate = formatDate(date);
+const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
+---
+
+<a href={`/blog/${post.id}/`} class="post-card">
+  <div class="post-card-badges">
+    <PillarBadge pillar={pillar} />
+    {series && <SeriesBadge series={series} />}
+  </div>
+
+  <h3 class="post-card-title">{title}</h3>
+
+  <p class="post-card-description">{description}</p>
+
+  <div class="post-card-meta">
+    <time datetime={date.toISOString()}>{displayDate}</time>
+    <span class="meta-separator" aria-hidden="true">&middot;</span>
+    <span>{minutes} min read</span>
+  </div>
+
+  {tags.length > 0 && <TagList tags={tags} />}
+</a>
+
+<style>
+  .post-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-6);
+    border-radius: var(--radius-lg);
+    text-decoration: none;
+    color: var(--color-text);
+    transition:
+      background-color var(--transition-normal),
+      box-shadow var(--transition-normal);
+  }
+
+  .post-card:hover {
+    background-color: var(--color-surface);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  .post-card-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .post-card-title {
+    font-size: var(--text-xl);
+    font-weight: 700;
+    line-height: var(--leading-tight);
+    color: var(--color-text);
+  }
+
+  .post-card-description {
+    font-size: var(--text-base);
+    line-height: var(--leading-normal);
+    color: var(--color-muted);
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .post-card-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+  }
+
+  .meta-separator {
+    user-select: none;
+  }
+</style>

--- a/src/components/PostCardFeatured.astro
+++ b/src/components/PostCardFeatured.astro
@@ -1,0 +1,100 @@
+---
+import PillarBadge from './PillarBadge.astro';
+import SeriesBadge from './SeriesBadge.astro';
+import TagList from './TagList.astro';
+import { formatDate } from '../lib/format-date';
+import { estimateReadingTime } from '../lib/reading-time';
+
+interface Props {
+  post: {
+    id: string;
+    body?: string;
+    data: {
+      title: string;
+      description: string;
+      date: Date;
+      pillar: string;
+      series?: string;
+      tags: string[];
+      readingTime?: number;
+    };
+  };
+}
+
+const { post } = Astro.props;
+const { title, description, date, pillar, series, tags, readingTime } = post.data;
+
+const displayDate = formatDate(date);
+const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
+---
+
+<a href={`/blog/${post.id}/`} class="post-card-featured">
+  <div class="post-card-featured-badges">
+    <PillarBadge pillar={pillar} />
+    {series && <SeriesBadge series={series} />}
+  </div>
+
+  <h2 class="post-card-featured-title">{title}</h2>
+
+  <p class="post-card-featured-description">{description}</p>
+
+  <div class="post-card-featured-meta">
+    <time datetime={date.toISOString()}>{displayDate}</time>
+    <span class="meta-separator" aria-hidden="true">&middot;</span>
+    <span>{minutes} min read</span>
+  </div>
+
+  {tags.length > 0 && <TagList tags={tags} />}
+</a>
+
+<style>
+  .post-card-featured {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-8);
+    border-radius: var(--radius-lg);
+    text-decoration: none;
+    color: var(--color-text);
+    transition:
+      background-color var(--transition-normal),
+      box-shadow var(--transition-normal);
+  }
+
+  .post-card-featured:hover {
+    background-color: var(--color-surface);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
+  }
+
+  .post-card-featured-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .post-card-featured-title {
+    font-size: var(--text-3xl);
+    font-weight: 700;
+    line-height: var(--leading-tight);
+    color: var(--color-text);
+  }
+
+  .post-card-featured-description {
+    font-size: var(--text-lg);
+    line-height: var(--leading-normal);
+    color: var(--color-muted);
+    margin: 0;
+  }
+
+  .post-card-featured-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+  }
+
+  .meta-separator {
+    user-select: none;
+  }
+</style>

--- a/src/components/SeriesBadge.astro
+++ b/src/components/SeriesBadge.astro
@@ -1,0 +1,31 @@
+---
+interface Props {
+  series: string;
+}
+
+const SERIES_LABELS: Record<string, string> = {
+  'ai-at-home': 'AI at Home',
+  'ai-at-work': 'AI at Work',
+  'ai-for-gigs': 'AI for Gigs',
+  'ai-mindset': 'AI Mindset',
+};
+
+const { series } = Astro.props;
+const label = SERIES_LABELS[series] ?? series;
+---
+
+<span class="series-badge">{label}</span>
+
+<style>
+  .series-badge {
+    display: inline-block;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    line-height: 1;
+    color: var(--color-bg);
+    background-color: var(--color-teal);
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,0 +1,48 @@
+---
+interface Props {
+  tags: string[];
+}
+
+const MAX_VISIBLE = 3;
+const { tags } = Astro.props;
+
+const visible = tags.slice(0, MAX_VISIBLE);
+const remaining = tags.length - MAX_VISIBLE;
+---
+
+{visible.length > 0 && (
+  <ul class="tag-list" role="list">
+    {visible.map((tag) => (
+      <li class="tag-chip">{tag}</li>
+    ))}
+    {remaining > 0 && (
+      <li class="tag-chip tag-more">+{remaining} more</li>
+    )}
+  </ul>
+)}
+
+<style>
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .tag-chip {
+    display: inline-block;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-xs);
+    line-height: 1;
+    color: var(--color-muted);
+    background-color: var(--color-surface);
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+  }
+
+  .tag-more {
+    font-style: italic;
+  }
+</style>

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,42 @@
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const RELATIVE_THRESHOLD_DAYS = 7;
+
+const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+/**
+ * Format a date as relative ("3 days ago") if within the last 7 days,
+ * or absolute ("Mar 15, 2026") otherwise.
+ */
+export function formatDate(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / MS_PER_DAY);
+
+  if (diffDays < 0) {
+    return formatAbsolute(date);
+  }
+
+  if (diffDays === 0) {
+    return 'Today';
+  }
+
+  if (diffDays === 1) {
+    return 'Yesterday';
+  }
+
+  if (diffDays < RELATIVE_THRESHOLD_DAYS) {
+    return `${diffDays} days ago`;
+  }
+
+  return formatAbsolute(date);
+}
+
+function formatAbsolute(date: Date): string {
+  const month = MONTH_NAMES[date.getMonth()];
+  const day = date.getDate();
+  const year = date.getFullYear();
+  return `${month} ${day}, ${year}`;
+}


### PR DESCRIPTION
## Summary

- Add `PillarBadge`, `SeriesBadge`, and `TagList` leaf components for post metadata display
- Add `PostCard` and `PostCardFeatured` Astro components that compose the badges, tag list, formatted date, and reading time into clickable `<a>` card elements with hover animations
- Add `src/lib/format-date.ts` utility for relative ("3 days ago") vs absolute ("Mar 15, 2026") date formatting with a 7-day threshold

Closes #6

## Test plan

- [ ] `npm run build` passes without errors
- [ ] Verify `PillarBadge` renders correct display names for all four pillar slugs
- [ ] Verify `SeriesBadge` renders correct display names for all four series slugs
- [ ] Verify `TagList` shows up to 3 tags and a "+N more" indicator when tags exceed 3
- [ ] Verify `PostCard` shows truncated description (2-line clamp), date, reading time, pillar badge, and optional series badge
- [ ] Verify `PostCardFeatured` renders larger title, more padding, full description (no truncation)
- [ ] Verify card hover produces warm surface background + shadow lift
- [ ] Verify entire card is a clickable `<a>` linking to `/blog/{post.id}/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)