### PR TITLE
Add 404 page, canonical URLs, and remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-how-do-i.ai

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -5,12 +5,15 @@ interface Props {
 }
 
 const { title, description } = Astro.props;
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content={description} />
+  <link rel="canonical" href={canonicalURL.href} />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
   <!-- Font preloads -->

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,59 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Page not found — How Do I AI" description="The page you are looking for does not exist.">
+  <section class="not-found">
+    <p class="not-found-code">404</p>
+    <h1>Page not found</h1>
+    <p class="not-found-message">
+      Sorry, the page you are looking for doesn't exist or has been moved.
+    </p>
+    <a href="/" class="not-found-link">&larr; Back to home</a>
+  </section>
+</BaseLayout>
+
+<style>
+  .not-found {
+    max-width: 480px;
+    margin-inline: auto;
+    padding-inline: var(--space-6);
+    padding-block: var(--space-16);
+    text-align: center;
+  }
+
+  .not-found-code {
+    font-size: var(--text-4xl);
+    font-weight: 700;
+    color: var(--color-accent);
+    margin-bottom: var(--space-2);
+  }
+
+  .not-found h1 {
+    font-size: var(--text-3xl);
+    margin-bottom: var(--space-4);
+  }
+
+  .not-found-message {
+    color: var(--color-muted);
+    font-size: var(--text-lg);
+    margin-bottom: var(--space-8);
+  }
+
+  .not-found-link {
+    display: inline-block;
+    font-weight: 600;
+    font-size: var(--text-base);
+    color: var(--color-accent);
+    text-decoration: none;
+    padding: var(--space-3) var(--space-6);
+    border: 2px solid var(--color-accent);
+    border-radius: var(--radius-md);
+    transition: background-color var(--transition-fast), color var(--transition-fast);
+  }
+
+  .not-found-link:hover {
+    background-color: var(--color-accent);
+    color: #fff;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Custom **404 page** (`src/pages/404.astro`) with nav, footer, brand colors/typography, and "Back to home" link
- **Canonical URLs** via `<link rel="canonical">` in `BaseHead.astro`, derived from `Astro.url.pathname` + site config
- **CNAME file removed** — custom domain is configured via GitHub repo Settings, not a repo file

## Test plan
- [ ] Visit a non-existent URL on the deployed site and confirm the custom 404 renders with nav and brand styling
- [ ] Inspect `<head>` on any page to verify `<link rel="canonical" href="https://how-do-i.ai/...">` is present
- [ ] Confirm no `CNAME` file exists at repo root
- [ ] Verify `npm run build` completes without errors

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)