### PR TITLE
Blog post page with navigation and related posts

### DIFF
--- a/src/components/PrevNextNav.astro
+++ b/src/components/PrevNextNav.astro
@@ -1,0 +1,96 @@
+---
+/**
+ * PrevNextNav — Chronological previous/next post links.
+ *
+ * Shows navigation to the chronologically adjacent posts.
+ * Newest post: no "Next" link. Oldest post: no "Previous" link.
+ *
+ * Props:
+ *   prevPost — the chronologically previous (older) post, or undefined
+ *   nextPost — the chronologically next (newer) post, or undefined
+ */
+
+interface Props {
+  prevPost?: { id: string; data: { title: string } };
+  nextPost?: { id: string; data: { title: string } };
+}
+
+const { prevPost, nextPost } = Astro.props;
+
+const showNav = prevPost || nextPost;
+---
+
+{showNav && (
+  <nav class="prev-next-nav" aria-label="Post navigation">
+    <div class="prev-next-inner">
+      {prevPost ? (
+        <a href={`/blog/${prevPost.id}/`} class="nav-link nav-prev">
+          <span class="nav-label" aria-hidden="true">&larr; Previous</span>
+          <span class="nav-title">{prevPost.data.title}</span>
+        </a>
+      ) : (
+        <span />
+      )}
+
+      {nextPost ? (
+        <a href={`/blog/${nextPost.id}/`} class="nav-link nav-next">
+          <span class="nav-label" aria-hidden="true">Next &rarr;</span>
+          <span class="nav-title">{nextPost.data.title}</span>
+        </a>
+      ) : (
+        <span />
+      )}
+    </div>
+  </nav>
+)}
+
+<style>
+  .prev-next-nav {
+    max-width: 680px;
+    margin-inline: auto;
+    padding-inline: var(--space-6);
+    padding-block: var(--space-8);
+    border-top: 1px solid var(--color-surface);
+  }
+
+  .prev-next-inner {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-6);
+  }
+
+  .nav-link {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    text-decoration: none;
+    max-width: 50%;
+    transition: color var(--transition-fast);
+  }
+
+  .nav-link:hover .nav-title {
+    color: var(--color-accent);
+  }
+
+  .nav-prev {
+    text-align: left;
+  }
+
+  .nav-next {
+    text-align: right;
+    margin-left: auto;
+  }
+
+  .nav-label {
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+    font-weight: 600;
+  }
+
+  .nav-title {
+    font-size: var(--text-base);
+    color: var(--color-text);
+    line-height: var(--leading-tight);
+    transition: color var(--transition-fast);
+  }
+</style>

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * RelatedPosts — Shows up to 3 related posts as PostCards.
+ *
+ * Expects pre-sorted posts (same-series first, then same-pillar).
+ * If fewer than 3 exist, shows fewer. No unrelated padding.
+ *
+ * Props:
+ *   posts — array of content collection entries (already filtered/sorted)
+ */
+
+import PostCard from './PostCard.astro';
+
+interface Props {
+  posts: {
+    id: string;
+    body?: string;
+    data: {
+      title: string;
+      description: string;
+      date: Date;
+      pillar: string;
+      series?: string;
+      tags: string[];
+      readingTime?: number;
+    };
+  }[];
+}
+
+const { posts } = Astro.props;
+---
+
+{posts.length > 0 && (
+  <aside class="related-posts" aria-label="Related posts">
+    <div class="related-posts-inner">
+      <h2 class="related-heading">Related Posts</h2>
+      <div class="related-grid">
+        {posts.map((post) => (
+          <PostCard post={post} />
+        ))}
+      </div>
+    </div>
+  </aside>
+)}
+
+<style>
+  .related-posts {
+    border-top: 1px solid var(--color-surface);
+    padding-block: var(--space-12);
+  }
+
+  .related-posts-inner {
+    max-width: 680px;
+    margin-inline: auto;
+    padding-inline: var(--space-6);
+  }
+
+  .related-heading {
+    font-size: var(--text-2xl);
+    font-weight: 700;
+    margin-bottom: var(--space-6);
+  }
+
+  .related-grid {
+    display: grid;
+    gap: var(--space-2);
+  }
+</style>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -36,7 +36,12 @@ const formattedDate = new Date(frontmatter.date).toLocaleDateString('en-US', {
 
 <article class="post">
   <header class="post-header">
+    <slot name="badges" />
     <h1 class="post-title">{frontmatter.title}</h1>
+
+    {frontmatter.description && (
+      <p class="post-description">{frontmatter.description}</p>
+    )}
 
     <div class="post-meta">
       <time datetime={new Date(frontmatter.date).toISOString()}>
@@ -72,10 +77,24 @@ const formattedDate = new Date(frontmatter.date).toLocaleDateString('en-US', {
     margin-bottom: var(--space-8);
   }
 
+  .post-header :global(.post-badges) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+  }
+
   .post-title {
     font-size: var(--text-4xl);
     font-weight: 700;
     line-height: var(--leading-tight);
+    margin-bottom: var(--space-4);
+  }
+
+  .post-description {
+    font-size: var(--text-lg);
+    color: var(--color-muted);
+    line-height: var(--leading-relaxed);
     margin-bottom: var(--space-4);
   }
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -36,9 +36,16 @@ export async function getPostsByTag(tag: string) {
   return posts.filter((post) => post.data.tags.includes(tag));
 }
 
-/** Get related posts (same pillar or shared tags), excluding the given post. */
+/**
+ * Get related posts, prioritising same-series > same-pillar > shared tags.
+ * Excludes the given post. Returns at most `limit` results; if fewer than
+ * `limit` qualify, returns only those (no unrelated padding).
+ */
 export async function getRelatedPosts(
-  post: { id: string; data: { pillar: Pillar; tags: string[] } },
+  post: {
+    id: string;
+    data: { pillar: Pillar; series?: Series; tags: string[] };
+  },
   limit = 3,
 ) {
   const posts = await getPublishedPosts();
@@ -47,7 +54,11 @@ export async function getRelatedPosts(
     .filter((p) => p.id !== post.id)
     .map((p) => {
       let score = 0;
+      // Same series is the strongest signal.
+      if (post.data.series && p.data.series === post.data.series) score += 4;
+      // Same pillar is the next signal.
       if (p.data.pillar === post.data.pillar) score += 2;
+      // Shared tags add incremental relevance.
       const sharedTags = p.data.tags.filter((t) =>
         post.data.tags.includes(t),
       ).length;

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,0 +1,70 @@
+---
+/**
+ * Blog post page — /blog/[slug]/
+ *
+ * Composes BaseLayout > BlogPostLayout > rendered markdown content,
+ * with PrevNextNav and RelatedPosts below the post.
+ */
+
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import BlogPostLayout from '../../layouts/BlogPostLayout.astro';
+import PillarBadge from '../../components/PillarBadge.astro';
+import SeriesBadge from '../../components/SeriesBadge.astro';
+import PrevNextNav from '../../components/PrevNextNav.astro';
+import RelatedPosts from '../../components/RelatedPosts.astro';
+import { getPublishedPosts, getRelatedPosts } from '../../lib/posts';
+import { estimateReadingTime } from '../../lib/reading-time';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { id: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content, headings } = await render(post);
+
+// Compute reading time from body if not set in frontmatter.
+const readingTime =
+  post.data.readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
+
+// Build frontmatter object for BlogPostLayout, including computed reading time.
+const frontmatter = { ...post.data, readingTime };
+
+// Get chronologically sorted published posts for prev/next navigation.
+// getPublishedPosts returns newest-first, so "next" (newer) is the post
+// before the current one in the array, and "prev" (older) is the post after.
+const allPosts = await getPublishedPosts();
+const currentIndex = allPosts.findIndex((p) => p.id === post.id);
+
+// In the newest-first array: index - 1 is the next (newer) post,
+// index + 1 is the previous (older) post.
+const nextPost = currentIndex > 0 ? allPosts[currentIndex - 1] : undefined;
+const prevPost =
+  currentIndex >= 0 && currentIndex < allPosts.length - 1
+    ? allPosts[currentIndex + 1]
+    : undefined;
+
+// Get related posts (same-series > same-pillar, up to 3).
+const relatedPosts = await getRelatedPosts(post, 3);
+---
+
+<BaseLayout
+  title={`${post.data.title} | How Do I AI`}
+  description={post.data.description}
+  activePillar={post.data.pillar}
+>
+  <BlogPostLayout frontmatter={frontmatter} headings={headings}>
+    <div class="post-badges" slot="badges">
+      <PillarBadge pillar={post.data.pillar} />
+      {post.data.series && <SeriesBadge series={post.data.series} />}
+    </div>
+    <Content />
+  </BlogPostLayout>
+
+  <PrevNextNav prevPost={prevPost} nextPost={nextPost} />
+  <RelatedPosts posts={relatedPosts} />
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Add blog post page route at `/blog/[slug]/` composing BaseLayout > BlogPostLayout > rendered content
- Create PrevNextNav component for chronological previous/next post links
- Create RelatedPosts component showing up to 3 related posts as PostCards
- Add pillar/series badges, description, and reading time to the post header
- Update `getRelatedPosts` scoring to prioritise same-series > same-pillar > shared tags

Closes #8

## Test plan
- [ ] `npm run build` succeeds and generates `/blog/sample-post/index.html`
- [ ] Post page renders badges (pillar + series), H1 title, description, date, and reading time
- [ ] PrevNextNav hidden when no adjacent posts exist (single-post case)
- [ ] RelatedPosts hidden when no related posts exist
- [ ] No sidebar, featured image, author byline, comments, or share buttons present

🤖 Generated with [Claude Code](https://claude.com/claude-code)