### PR TITLE
(fix) filter drafts in blog post page getStaticPaths

### DIFF
--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -17,7 +17,7 @@ import { getPublishedPosts, getRelatedPosts } from '../../lib/posts';
 import { estimateReadingTime } from '../../lib/reading-time';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
   return posts.map((post) => ({
     params: { id: post.id },
     props: { post },


### PR DESCRIPTION
## Summary
- Apply `data.draft === false` filter in `getStaticPaths` for `/blog/[...id].astro`
- Draft posts no longer generate publicly accessible HTML pages

Closes #34

## Test plan
- [x] `npm run build` succeeds
- [ ] Manual: set a post to `draft: true`, confirm no `dist/blog/{slug}/index.html` is generated
- [ ] Manual: existing published content still builds and renders