### PR TITLE
(chore) ignore .tmp/ and .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ dist/
 # Astro generated types
 .astro/
 
+# Temporary scratch files
+.tmp/
+
+# Claude Code project configuration
+.claude/
+
 ## Origin: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General
 .DS_Store


### PR DESCRIPTION
## Summary
- Add `.tmp/` and `.claude/` to `## Project-specific` section of `.gitignore`
- Preserves the verbatim upstream template sections (per #27 convention)

Closes #36

## Test plan
- [x] `git status` on a clean tree does not show these directories as untracked