### PR TITLE
(fix) always render absolute dates in format-date

### DIFF
--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,40 +1,17 @@
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
-const RELATIVE_THRESHOLD_DAYS = 7;
-
 const MONTH_NAMES = [
   'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 ];
 
 /**
- * Format a date as relative ("3 days ago") if within the last 7 days,
- * or absolute ("Mar 15, 2026") otherwise.
+ * Format a date as an absolute string ("Mar 15, 2026").
+ *
+ * Relative labels ("Today", "N days ago") are intentionally not used:
+ * in a static-site-generation context the comparison to `new Date()`
+ * happens at build time, so labels become stale as soon as the site
+ * is deployed and viewed on a later day.
  */
 export function formatDate(date: Date): string {
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / MS_PER_DAY);
-
-  if (diffDays < 0) {
-    return formatAbsolute(date);
-  }
-
-  if (diffDays === 0) {
-    return 'Today';
-  }
-
-  if (diffDays === 1) {
-    return 'Yesterday';
-  }
-
-  if (diffDays < RELATIVE_THRESHOLD_DAYS) {
-    return `${diffDays} days ago`;
-  }
-
-  return formatAbsolute(date);
-}
-
-function formatAbsolute(date: Date): string {
   const month = MONTH_NAMES[date.getMonth()];
   const day = date.getDate();
   const year = date.getFullYear();


### PR DESCRIPTION
## Summary
- Remove relative-date branch (\"Today\", \"Yesterday\", \"N days ago\")
- Always return absolute \"Mon DD, YYYY\"
- Implements Option A from #39 — simplest, zero staleness

Relative labels captured `new Date()` at build time; in a static-site context they became stale as soon as the site was viewed on a later day. Option B (client-side hydration) was rejected as over-engineered for the cosmetic benefit. Option C (daily rebuild) burns CI minutes with 24h worst-case staleness.

Closes #39

## Test plan
- [x] `npm run build` succeeds
- [ ] Blog cards on home and blog index display absolute dates