### PR TITLE
(fix) use shadow tokens for card hover visibility in dark mode

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -63,7 +63,7 @@ const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
 
   .post-card:hover {
     background-color: var(--color-surface);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-card);
   }
 
   .post-card-badges {

--- a/src/components/PostCardFeatured.astro
+++ b/src/components/PostCardFeatured.astro
@@ -63,7 +63,7 @@ const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
 
   .post-card-featured:hover {
     background-color: var(--color-surface);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-card-featured);
   }
 
   .post-card-featured-badges {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -74,6 +74,10 @@
   /* Transitions */
   --transition-fast: 150ms ease;
   --transition-normal: 250ms ease;
+
+  /* Shadows — card hover elevation */
+  --shadow-card: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-card-featured: 0 6px 20px rgba(0, 0, 0, 0.1);
 }
 
 /* --------------------------------------------------------------------------
@@ -88,6 +92,10 @@
   --color-muted: #9CA3AF;
   --color-teal: #3CC4BE;
   --color-amber: #D4911E;
+
+  /* Shadows — darker base for visibility on dark surfaces */
+  --shadow-card: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-card-featured: 0 6px 20px rgba(0, 0, 0, 0.5);
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `--shadow-card` and `--shadow-card-featured` design tokens to `global.css`
- Dark mode overrides them with higher alpha (0.4 / 0.5) to stay visible on the #2A2A2A background
- `PostCard` and `PostCardFeatured` consume the tokens

Closes #40

## Test plan
- [x] `npm run build` succeeds
- [ ] Manual: hover cards in light mode — visible elevation, unchanged from before
- [ ] Manual: hover cards in dark mode — visible elevation (previously invisible)