### PR TITLE
(feat) add Content Security Policy meta tag

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -26,6 +26,21 @@ const imageURL = new URL(image, Astro.site);
   <link rel="canonical" href={canonicalURL.href} />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
+  <!--
+    Content Security Policy.
+
+    'unsafe-inline' on script-src covers the theme-flash script below.
+    'unsafe-inline' on style-src covers Astro's scoped component styles,
+    which are emitted as inline <style> blocks per component.
+    A future hardening step is to generate build-time hashes for the
+    inline script and replace script-src 'unsafe-inline' with a hash
+    allowlist.
+  -->
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+  />
+
   <!-- Open Graph -->
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />


### PR DESCRIPTION
## Summary
- Add restrictive CSP meta tag to \`BaseHead.astro\`
- Covers script-src, style-src, font-src, img-src, connect-src, base-uri, form-action, frame-ancestors
- \`'unsafe-inline'\` required for script-src (theme-flash) and style-src (Astro scoped styles) — documented in source comment

Closes #38

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Manual: \`npm run preview\`; open browser devtools console; verify no CSP violations on home, blog index, blog post, 404
- [ ] Manual: theme toggle, blog filter, pagination all still function