### PR TITLE
(chore) npm audit fix: vite 6.4.1 → 6.4.2 to unblock CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5006,9 +5006,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",


### PR DESCRIPTION
## Summary
- Lock-file-only bump: vite 6.4.1 → 6.4.2
- Resolves GHSA-4w7w-66w2-5vf9 and GHSA-p9ff-h696-f583
- Both advisories only affect the vite dev server; the deployed static site has no dev-server surface
- The CI \`npm audit --omit=dev\` step is blocking and every open PR is currently failing on this, so merging this first unblocks the rest

## Test plan
- [x] \`npm audit --omit=dev\` clean locally
- [x] \`npm run build\` succeeds