### PR TITLE
(refactor) centralize pillar/series taxonomy in src/lib/taxonomy.ts

### DIFF
--- a/src/components/BlogFilter.astro
+++ b/src/components/BlogFilter.astro
@@ -194,21 +194,12 @@
 </style>
 
 <script>
+  import { PILLARS, SERIES } from '../lib/taxonomy';
+
   const POSTS_PER_PAGE = 12;
 
-  const PILLAR_LABELS: Record<string, string> = {
-    'ai-first-thinking': 'AI-First Thinking',
-    'ai-in-practice': 'AI in Practice',
-    'tools-and-workflows': 'Tools & Workflows',
-    'behind-the-scenes': 'Behind the Scenes',
-  };
-
-  const SERIES_LABELS: Record<string, string> = {
-    'ai-at-home': 'AI at Home',
-    'ai-at-work': 'AI at Work',
-    'ai-for-gigs': 'AI for Gigs',
-    'ai-mindset': 'AI Mindset',
-  };
+  const PILLAR_LABELS: Record<string, string> = PILLARS;
+  const SERIES_LABELS: Record<string, string> = SERIES;
 
   function init() {
     const grid = document.getElementById('post-grid');

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,7 @@
 ---
 import { getPostsByPillar } from '../lib/posts';
 import ThemeToggle from './ThemeToggle.astro';
+import { PILLARS } from '../lib/taxonomy';
 
 interface Props {
   activePillar?: string;
@@ -11,15 +12,11 @@ const { activePillar } = Astro.props;
 const btsPosts = await getPostsByPillar('behind-the-scenes');
 const showBts = btsPosts.length > 0;
 
-const pillars = [
-  { slug: 'ai-first-thinking', label: 'AI-First Thinking' },
-  { slug: 'ai-in-practice', label: 'AI in Practice' },
-  { slug: 'tools-and-workflows', label: 'Tools & Workflows' },
-];
-
-if (showBts) {
-  pillars.push({ slug: 'behind-the-scenes', label: 'Behind the Scenes' });
-}
+// Nav surfaces all pillars except Behind-the-Scenes, which only shows
+// once there is at least one published post in that pillar.
+const pillars = Object.entries(PILLARS)
+  .filter(([slug]) => slug !== 'behind-the-scenes' || showBts)
+  .map(([slug, label]) => ({ slug, label }));
 ---
 
 <nav class="site-nav" aria-label="Main navigation">

--- a/src/components/PillarBadge.astro
+++ b/src/components/PillarBadge.astro
@@ -1,17 +1,12 @@
 ---
+import { PILLARS, type PillarSlug } from '../lib/taxonomy';
+
 interface Props {
-  pillar: string;
+  pillar: PillarSlug | string;
 }
 
-const PILLAR_LABELS: Record<string, string> = {
-  'ai-first-thinking': 'AI-First Thinking',
-  'ai-in-practice': 'AI in Practice',
-  'tools-and-workflows': 'Tools & Workflows',
-  'behind-the-scenes': 'Behind the Scenes',
-};
-
 const { pillar } = Astro.props;
-const label = PILLAR_LABELS[pillar] ?? pillar;
+const label = (PILLARS as Record<string, string>)[pillar] ?? pillar;
 ---
 
 <span class="pillar-badge">{label}</span>

--- a/src/components/SeriesBadge.astro
+++ b/src/components/SeriesBadge.astro
@@ -1,17 +1,12 @@
 ---
+import { SERIES, type SeriesSlug } from '../lib/taxonomy';
+
 interface Props {
-  series: string;
+  series: SeriesSlug | string;
 }
 
-const SERIES_LABELS: Record<string, string> = {
-  'ai-at-home': 'AI at Home',
-  'ai-at-work': 'AI at Work',
-  'ai-for-gigs': 'AI for Gigs',
-  'ai-mindset': 'AI Mindset',
-};
-
 const { series } = Astro.props;
-const label = SERIES_LABELS[series] ?? series;
+const label = (SERIES as Record<string, string>)[series] ?? series;
 ---
 
 <span class="series-badge">{label}</span>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
+import { PILLAR_SLUGS, SERIES_SLUGS } from './lib/taxonomy';
 
 const blog = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
@@ -7,15 +8,8 @@ const blog = defineCollection({
     title: z.string(),
     description: z.string(),
     date: z.coerce.date(),
-    pillar: z.enum([
-      'ai-first-thinking',
-      'ai-in-practice',
-      'tools-and-workflows',
-      'behind-the-scenes',
-    ]),
-    series: z
-      .enum(['ai-at-home', 'ai-at-work', 'ai-for-gigs', 'ai-mindset'])
-      .optional(),
+    pillar: z.enum(PILLAR_SLUGS),
+    series: z.enum(SERIES_SLUGS).optional(),
     tags: z.array(z.string()).default([]),
     readingTime: z.number().optional(),
     draft: z.boolean().default(false),

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,12 +1,8 @@
 import { getCollection } from 'astro:content';
+import type { PillarSlug, SeriesSlug } from './taxonomy';
 
-type Pillar =
-  | 'ai-first-thinking'
-  | 'ai-in-practice'
-  | 'tools-and-workflows'
-  | 'behind-the-scenes';
-
-type Series = 'ai-at-home' | 'ai-at-work' | 'ai-for-gigs' | 'ai-mindset';
+type Pillar = PillarSlug;
+type Series = SeriesSlug;
 
 function sortByDateDesc<T extends { data: { date: Date } }>(posts: T[]): T[] {
   return posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -1,0 +1,33 @@
+/**
+ * Single source of truth for content taxonomy (pillars and series).
+ *
+ * All consumers — Zod schema, badge components, nav, client-side filter,
+ * post type aliases — must import from this module rather than defining
+ * their own copy. Adding or renaming a pillar/series happens here, once.
+ */
+
+export const PILLARS = {
+  'ai-first-thinking': 'AI-First Thinking',
+  'ai-in-practice': 'AI in Practice',
+  'tools-and-workflows': 'Tools & Workflows',
+  'behind-the-scenes': 'Behind the Scenes',
+} as const;
+
+export const SERIES = {
+  'ai-at-home': 'AI at Home',
+  'ai-at-work': 'AI at Work',
+  'ai-for-gigs': 'AI for Gigs',
+  'ai-mindset': 'AI Mindset',
+} as const;
+
+export type PillarSlug = keyof typeof PILLARS;
+export type SeriesSlug = keyof typeof SERIES;
+
+export const PILLAR_SLUGS = Object.keys(PILLARS) as [
+  PillarSlug,
+  ...PillarSlug[],
+];
+export const SERIES_SLUGS = Object.keys(SERIES) as [
+  SeriesSlug,
+  ...SeriesSlug[],
+];


### PR DESCRIPTION
## Summary
- New \`src/lib/taxonomy.ts\` as single source of truth
- Exports: \`PILLARS\`, \`SERIES\` (slug→label), \`PillarSlug\`/\`SeriesSlug\` types, \`PILLAR_SLUGS\`/\`SERIES_SLUGS\` tuples
- Updated 5+ consumers: \`content.config.ts\` (Zod enum), \`PillarBadge\`, \`SeriesBadge\`, \`Nav\`, \`BlogFilter\` (client script), \`lib/posts.ts\` (type aliases)
- Adding or renaming a pillar/series is now a single-file change

Closes #35

## Test plan
- [x] \`npm run build\` succeeds
- [x] \`grep\` confirms no hardcoded pillar/series slugs remain outside \`taxonomy.ts\`
- [ ] Manual: home, blog index, blog post — badges render, nav links present, filter chips work