### PR TITLE
(fix) honor [hidden] on .pagination to kill FOUC

### DIFF
--- a/src/components/BlogFilter.astro
+++ b/src/components/BlogFilter.astro
@@ -122,6 +122,14 @@
     flex-wrap: wrap;
   }
 
+  /* Honor the [hidden] HTML attribute regardless of the display value
+     above. Without this, the UA rule `[hidden] { display: none }` is
+     overridden by `.pagination { display: flex }`, producing a flash of
+     the Previous/Next buttons before init() runs and hides them. */
+  .pagination[hidden] {
+    display: none;
+  }
+
   .pagination-btn {
     padding: var(--space-2) var(--space-4);
     min-height: 44px;


### PR DESCRIPTION
## Summary
- Add \`.pagination[hidden] { display: none }\` override
- The \`[hidden]\` HTML attribute on \`<nav class=\"pagination\" hidden>\` was being beaten by \`.pagination { display: flex }\`, causing a brief flash of Previous/Next buttons on page load before JS hid them

Closes #41

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Manual: \`/blog/\` with one post — no flash of pagination
- [ ] Manual: \`/blog/\` with multi-page content — pagination still appears correctly after init