### PR TITLE
(feat) add Vitest and initial unit tests for lib/

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
         "astro": "^5.7.10"
+      },
+      "devDependencies": {
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1593,6 +1596,24 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1601,6 +1622,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1670,6 +1698,119 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1811,6 +1952,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -1974,6 +2125,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2091,6 +2252,13 @@
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
       "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "license": "ISC"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2480,6 +2648,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3857,6 +4035,17 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -3984,6 +4173,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -4441,6 +4637,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -4496,6 +4699,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -4592,6 +4809,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -4615,6 +4839,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -5555,6 +5789,103 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -5572,6 +5903,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "astro": "^5.7.10"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.4"
   }
 }

--- a/src/lib/format-date.test.ts
+++ b/src/lib/format-date.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from './format-date';
+
+describe('formatDate', () => {
+  it('formats January correctly', () => {
+    expect(formatDate(new Date(2026, 0, 15))).toBe('Jan 15, 2026');
+  });
+
+  it('formats December correctly', () => {
+    expect(formatDate(new Date(2024, 11, 31))).toBe('Dec 31, 2024');
+  });
+
+  it('handles single-digit days without padding', () => {
+    expect(formatDate(new Date(2026, 2, 1))).toBe('Mar 1, 2026');
+    expect(formatDate(new Date(2026, 2, 9))).toBe('Mar 9, 2026');
+  });
+
+  it('handles all twelve months', () => {
+    const expected = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    expected.forEach((abbr, i) => {
+      expect(formatDate(new Date(2026, i, 1))).toBe(`${abbr} 1, 2026`);
+    });
+  });
+
+  it('does not apply locale reordering', () => {
+    // Should always be "MMM D, YYYY" regardless of system locale.
+    expect(formatDate(new Date(2026, 5, 7))).toBe('Jun 7, 2026');
+  });
+
+  it('reflects the local calendar date (not UTC) for Date-only inputs', () => {
+    // new Date(YYYY, M, D) uses local TZ; the formatter reads the same
+    // local components, so this is stable on every machine.
+    const d = new Date(2025, 6, 4); // July 4, 2025 local
+    expect(formatDate(d)).toBe('Jul 4, 2025');
+  });
+});

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock `astro:content` before importing the module under test, so the
+// virtual Astro module resolves to an in-test fake.
+const getCollectionMock = vi.fn();
+
+vi.mock('astro:content', () => ({
+  getCollection: getCollectionMock,
+}));
+
+// Import after the mock is registered.
+const {
+  getPublishedPosts,
+  getRelatedPosts,
+  getPostsByPillar,
+  getPostsBySeries,
+  getPostsByTag,
+} = await import('./posts');
+
+type TestPost = {
+  id: string;
+  data: {
+    title: string;
+    description: string;
+    date: Date;
+    pillar: string;
+    series?: string;
+    tags: string[];
+    draft: boolean;
+  };
+};
+
+function post(overrides: Partial<TestPost> & { id: string }): TestPost {
+  return {
+    id: overrides.id,
+    data: {
+      title: 't',
+      description: 'd',
+      date: new Date(2025, 0, 1),
+      pillar: 'ai-in-practice',
+      tags: [],
+      draft: false,
+      ...overrides.data,
+    },
+  };
+}
+
+beforeEach(() => {
+  getCollectionMock.mockReset();
+});
+
+describe('getPublishedPosts', () => {
+  it('filters out drafts via the predicate', async () => {
+    getCollectionMock.mockImplementation(
+      async (_name: string, predicate?: (p: TestPost) => boolean) => {
+        const all = [
+          post({ id: 'a', data: { date: new Date(2025, 0, 1), draft: false } }),
+          post({ id: 'b', data: { date: new Date(2025, 0, 2), draft: true } }),
+        ];
+        return predicate ? all.filter(predicate) : all;
+      },
+    );
+    const result = await getPublishedPosts();
+    expect(result.map((p) => p.id)).toEqual(['a']);
+  });
+
+  it('sorts newest first', async () => {
+    getCollectionMock.mockImplementation(async () => [
+      post({ id: 'old', data: { date: new Date(2020, 0, 1) } }),
+      post({ id: 'new', data: { date: new Date(2026, 0, 1) } }),
+      post({ id: 'mid', data: { date: new Date(2023, 0, 1) } }),
+    ]);
+    const result = await getPublishedPosts();
+    expect(result.map((p) => p.id)).toEqual(['new', 'mid', 'old']);
+  });
+});
+
+describe('getPostsByPillar / getPostsBySeries / getPostsByTag', () => {
+  beforeEach(() => {
+    getCollectionMock.mockImplementation(async () => [
+      post({
+        id: 'p1',
+        data: { pillar: 'ai-in-practice', series: 'ai-at-work', tags: ['llms'] },
+      }),
+      post({
+        id: 'p2',
+        data: { pillar: 'tools-and-workflows', series: 'ai-for-gigs', tags: ['ide'] },
+      }),
+      post({
+        id: 'p3',
+        data: { pillar: 'ai-in-practice', tags: ['llms', 'rag'] },
+      }),
+    ]);
+  });
+
+  it('filters by pillar', async () => {
+    const result = await getPostsByPillar('ai-in-practice');
+    expect(result.map((p) => p.id).sort()).toEqual(['p1', 'p3']);
+  });
+
+  it('filters by series', async () => {
+    const result = await getPostsBySeries('ai-at-work');
+    expect(result.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('filters by tag', async () => {
+    const result = await getPostsByTag('llms');
+    expect(result.map((p) => p.id).sort()).toEqual(['p1', 'p3']);
+  });
+});
+
+describe('getRelatedPosts', () => {
+  it('scores same-series higher than same-pillar', async () => {
+    getCollectionMock.mockImplementation(async () => [
+      post({
+        id: 'current',
+        data: { pillar: 'ai-in-practice', series: 'ai-at-work', tags: ['a'] },
+      }),
+      post({
+        id: 'same-pillar-only',
+        data: { pillar: 'ai-in-practice', tags: [] },
+      }),
+      post({
+        id: 'same-series-only',
+        data: { pillar: 'tools-and-workflows', series: 'ai-at-work', tags: [] },
+      }),
+    ]);
+    const current = post({
+      id: 'current',
+      data: { pillar: 'ai-in-practice', series: 'ai-at-work', tags: ['a'] },
+    });
+    const result = await getRelatedPosts(current, 3);
+    expect(result.map((p) => p.id)).toEqual([
+      'same-series-only', // series = 4 > pillar = 2
+      'same-pillar-only',
+    ]);
+  });
+
+  it('counts shared tags as incremental relevance', async () => {
+    getCollectionMock.mockImplementation(async () => [
+      post({
+        id: 'current',
+        data: { pillar: 'ai-in-practice', tags: ['a', 'b'] },
+      }),
+      post({
+        id: 'tags-only',
+        data: { pillar: 'behind-the-scenes', tags: ['a', 'b'] },
+      }),
+      post({
+        id: 'pillar-no-tags',
+        data: { pillar: 'ai-in-practice', tags: [] },
+      }),
+    ]);
+    const current = post({
+      id: 'current',
+      data: { pillar: 'ai-in-practice', tags: ['a', 'b'] },
+    });
+    const result = await getRelatedPosts(current, 3);
+    // pillar-no-tags: score 2 (pillar). tags-only: score 2 (two shared tags).
+    // Both qualify; tied scores fall back to original order.
+    expect(result.map((p) => p.id).sort()).toEqual([
+      'pillar-no-tags',
+      'tags-only',
+    ]);
+  });
+
+  it('excludes the post itself', async () => {
+    getCollectionMock.mockImplementation(async () => [
+      post({ id: 'current', data: { pillar: 'ai-in-practice', tags: ['a'] } }),
+    ]);
+    const current = post({
+      id: 'current',
+      data: { pillar: 'ai-in-practice', tags: ['a'] },
+    });
+    const result = await getRelatedPosts(current, 3);
+    expect(result).toEqual([]);
+  });
+
+  it('returns at most `limit` results', async () => {
+    getCollectionMock.mockImplementation(async () =>
+      [1, 2, 3, 4, 5].map((i) =>
+        post({ id: `p${i}`, data: { pillar: 'ai-in-practice' } }),
+      ),
+    );
+    const current = post({ id: 'current', data: { pillar: 'ai-in-practice' } });
+    const result = await getRelatedPosts(current, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters out zero-score posts (no pillar/series/tag overlap)', async () => {
+    getCollectionMock.mockImplementation(async () => [
+      post({
+        id: 'unrelated',
+        data: { pillar: 'behind-the-scenes', tags: ['other'] },
+      }),
+    ]);
+    const current = post({
+      id: 'current',
+      data: { pillar: 'ai-in-practice', tags: ['rag'] },
+    });
+    const result = await getRelatedPosts(current, 3);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/reading-time.test.ts
+++ b/src/lib/reading-time.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { estimateReadingTime } from './reading-time';
+
+describe('estimateReadingTime', () => {
+  it('returns 1 minute for empty string', () => {
+    expect(estimateReadingTime('')).toBe(1);
+  });
+
+  it('returns 1 minute for whitespace-only content', () => {
+    expect(estimateReadingTime('   \n\t  ')).toBe(1);
+  });
+
+  it('returns 1 minute for content below 1-minute threshold', () => {
+    // 50 words at 220 wpm ≈ 0.22 min → rounds to 0 → clamped to 1
+    const text = 'word '.repeat(50).trim();
+    expect(estimateReadingTime(text)).toBe(1);
+  });
+
+  it('rounds 330 words to 2 minutes (330 / 220 = 1.5 → 2)', () => {
+    const text = 'word '.repeat(330).trim();
+    expect(estimateReadingTime(text)).toBe(2);
+  });
+
+  it('rounds 220 words to 1 minute', () => {
+    const text = 'word '.repeat(220).trim();
+    expect(estimateReadingTime(text)).toBe(1);
+  });
+
+  it('rounds 1100 words to 5 minutes', () => {
+    const text = 'word '.repeat(1100).trim();
+    expect(estimateReadingTime(text)).toBe(5);
+  });
+
+  it('collapses multiple whitespace into single word boundary', () => {
+    // Three words separated by mixed whitespace, not 10
+    expect(estimateReadingTime('one\n\ntwo\t  three')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add \`vitest\` devDependency + \`test\` / \`test:watch\` scripts
- New unit tests:
  - \`reading-time.test.ts\` — empty/whitespace → 1 min, rounding boundaries, whitespace collapse
  - \`format-date.test.ts\` — all 12 month abbreviations, single-digit days, stable across locales
  - \`posts.test.ts\` — draft filtering, date-desc sorting, pillar/series/tag filters, related-post scoring (series=4 > pillar=2 > shared tag=1, self-exclusion, limit, zero-score filter)
- \`posts.test.ts\` uses \`vi.mock('astro:content')\` to stub the virtual Astro collection module
- **23 tests pass locally**

Out of scope per issue: component tests, e2e/visual regression, coverage thresholds.

Closes #29

## Test plan
- [x] \`npm run test\` → 23 passed