### PR TITLE
(fix) remove continue-on-error from CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,12 @@ jobs:
 
       - name: Lint
         run: npm run lint
-        continue-on-error: true
 
       - name: Type check
         run: npm run typecheck
-        continue-on-error: true
 
       - name: Test
         run: npm run test
-        continue-on-error: true
 
       - name: Build
         run: npm run build

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -17,20 +17,25 @@ const {
   getPostsByTag,
 } = await import('./posts');
 
+import type { PillarSlug, SeriesSlug } from './taxonomy';
+
 type TestPost = {
   id: string;
   data: {
     title: string;
     description: string;
     date: Date;
-    pillar: string;
-    series?: string;
+    pillar: PillarSlug;
+    series?: SeriesSlug;
     tags: string[];
     draft: boolean;
   };
 };
 
-function post(overrides: Partial<TestPost> & { id: string }): TestPost {
+function post(overrides: {
+  id: string;
+  data?: Partial<TestPost['data']>;
+}): TestPost {
   return {
     id: overrides.id,
     data: {


### PR DESCRIPTION
## Summary
- Remove \`continue-on-error: true\` from the \`Lint\`, \`Type check\`, and \`Test\` steps in \`.github/workflows/ci.yml\`
- Quality failures now block the build

Closes #30

## Merge order (required)
This PR must land **AFTER** these two, because without them the quality scripts don't exist and CI will hard-fail:

1. **#29** — adds \`npm run test\` via Vitest (PR #54)
2. **#33** — adds \`npm run lint\` + \`npm run typecheck\` via ESLint/astro check (PR #49)
3. **this PR**

## Test plan
- [ ] After merging #29 and #33 first, CI on this PR passes
- [ ] A deliberate lint/type/test failure in a separate PR would get blocked