### PR TITLE
ship /about/ methodology page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -54,6 +54,9 @@ const channels: Channel[] = [
 <footer class="site-footer">
   <div class="footer-inner">
     <p class="tagline">AI first. For all of it.</p>
+    <nav class="footer-primary" aria-label="Site">
+      <a href="/about/" class="footer-link">About</a>
+    </nav>
     <nav class="channels" aria-label="Channels">
       <ul class="channel-list" role="list">
         {
@@ -128,6 +131,28 @@ const channels: Channel[] = [
     font-size: var(--text-sm);
     color: var(--color-muted);
     margin: 0;
+  }
+
+  .footer-primary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .footer-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: var(--space-2) 0;
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .footer-link:hover,
+  .footer-link:focus-visible {
+    color: var(--color-accent);
   }
 
   .channel-list {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,129 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="About How Do I AI?"
+  description="What How Do I AI? is, how it's made, and why it isn't attributed to a person. A question brand, not a personal brand."
+>
+  <article class="about">
+    <header class="about-header">
+      <h1>About How Do I AI<span class="question-mark">?</span></h1>
+      <p class="lede">
+        A content publication built around one question:
+        <em>"How would I do this if AI could do anything?"</em>
+      </p>
+    </header>
+
+    <div class="prose">
+      <p>
+        That's the Default Question. Not a philosophy, not a framework, not a
+        mindset to internalize. It's the question you ask before you plan a task
+        — before you outline, open a tool, or fire up a chat. Change the
+        question you start with, and the work that follows changes too.
+      </p>
+
+      <h2>What this is</h2>
+      <p>
+        A publication, not a personal brand. Multi-format content — blog, video,
+        podcast — about applying AI to real work: drafting, planning, household
+        logistics, side gigs, creative projects, shipping code. Practitioner
+        walkthroughs with real workflows, real results, and the parts that
+        didn't work.
+      </p>
+      <p>
+        No "Top 10 Tools" lists. No courses to sell. No "AI will change
+        everything" hype.
+      </p>
+
+      <h2>The editorial position</h2>
+      <p>
+        Not neutral. The Default Question is the position. Every piece on this
+        site argues — directly or by example — that starting with "how would I
+        do this if AI could do anything?" produces different work than starting
+        with "can AI help?". That's the stake in the ground.
+      </p>
+      <p>
+        Opinions back it up. Tool assessments include the parts that don't work.
+        "It depends" isn't a conclusion here.
+      </p>
+
+      <h2>How it's made</h2>
+      <p>
+        AI-first, end to end. Research, drafting, structuring, editing, visuals,
+        code, copy — all heavily AI-assisted. A single human operator sets
+        direction, tests every claim, and approves the output before it ships.
+      </p>
+      <p>
+        The release gate is simple: the walkthrough has to actually work when
+        someone tries it. If a claim isn't grounded in hands-on use, it gets
+        cut. If a demo doesn't reproduce, the draft doesn't ship.
+      </p>
+      <p>AI writes. A human decides what's true.</p>
+
+      <h2>Why no personal attribution</h2>
+      <p>
+        Intentional. How Do I AI? is a question brand, not a personality brand.
+        The content has to earn trust from substance alone — if a post only
+        lands because a face or biography is attached, it isn't good enough.
+      </p>
+      <p>
+        It's also honest about the setup: a solo operator running an AI-first
+        workflow, publishing under the brand's name. The work on the page isn't
+        the author's performance. The Default Question is.
+      </p>
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .about {
+    max-width: 680px;
+    margin-inline: auto;
+    padding-inline: var(--space-6);
+    padding-block: var(--space-12) var(--space-16);
+  }
+
+  .about-header {
+    margin-bottom: var(--space-8);
+  }
+
+  .about-header h1 {
+    font-size: var(--text-4xl);
+    font-weight: 700;
+    line-height: var(--leading-tight);
+    margin-bottom: var(--space-4);
+  }
+
+  .question-mark {
+    color: var(--color-accent);
+  }
+
+  .lede {
+    font-size: var(--text-lg);
+    color: var(--color-muted);
+    line-height: var(--leading-relaxed);
+    margin-block: 0;
+  }
+
+  .lede em {
+    font-style: italic;
+    color: var(--color-text);
+  }
+
+  .prose {
+    font-size: var(--text-lg);
+    line-height: 1.7;
+    color: var(--color-text);
+  }
+
+  .prose h2 {
+    font-size: var(--text-2xl);
+    margin-top: var(--space-12);
+    margin-bottom: var(--space-4);
+  }
+
+  .prose p {
+    margin-block: var(--space-4);
+  }
+</style>


### PR DESCRIPTION
Closes #62.

## Summary
- New Astro route `src/pages/about.astro` rendering at `/about/` via `BaseLayout`
- Body copy lands the four required statements:
  - what HDIAI is (publication, not personal brand)
  - how it's made (AI-first, solo human operator, reproducibility as release gate)
  - why no personal attribution (intentional — content earns trust from substance)
  - the Default Question as editorial position (not neutral)
- ~346 words, single-screen, no marketing fluff
- Unique OG title (`About How Do I AI?`) and description
- Footer gains an About link alongside RSS (tagline preserved)

## Voice gate
- No "we" / "our"; no hedging without follow-through; no corporate-speak
- Opinionated, concrete, candid — matches `hq/brand/identity.md`

## Test plan
- [x] `npm run build` succeeds; `/about/index.html` generated
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean (pre-existing warnings unchanged)
- [x] `npm run test` passes (23/23)
- [x] `npm run format:check` clean
- [ ] Visual check in browser at `/about/` (CI/reviewer)
- [ ] Lighthouse accessibility ≥ 90 (CI/reviewer — structural checks pass: semantic HTML, skip link, `lang="en"`, `--color-muted` contrast ≥4.9:1, 44px touch targets, focus-visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)