### PR TITLE
(feat) add Plausible Analytics (cookieless) page-view tracking

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -48,13 +48,15 @@ const imageURL = new URL(image, Astro.site);
     'unsafe-inline' on script-src covers the theme-flash script below.
     'unsafe-inline' on style-src covers Astro's scoped component styles,
     which are emitted as inline <style> blocks per component.
+    https://plausible.io on script-src and connect-src covers the
+    Plausible Analytics script and its event endpoint.
     A future hardening step is to generate build-time hashes for the
     inline script and replace script-src 'unsafe-inline' with a hash
     allowlist.
   -->
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+    content="default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://plausible.io; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
   />
 
   <!-- Open Graph -->
@@ -104,6 +106,13 @@ const imageURL = new URL(image, Astro.site);
       }
     })();
   </script>
+
+  <!-- Plausible Analytics: cookieless, privacy-friendly page-view tracking -->
+  <script
+    is:inline
+    defer
+    data-domain="how-do-i.ai"
+    src="https://plausible.io/js/script.js"></script>
 
   <title>{title}</title>
 </head>


### PR DESCRIPTION
Closes #61.

## Summary
- Adds a deferred, cookieless Plausible `<script>` to `src/components/BaseHead.astro` with `data-domain="how-do-i.ai"`.
- Extends the CSP meta allowlist to permit `https://plausible.io` on `script-src` (script load) and `connect-src` (`/api/event` POST).
- Extends the CSP block comment to document the new allowlist entry.

## Acceptance-criteria trace
- AC2 (Plausible `<script>` in `BaseHead.astro`): shipped. Verified in built HTML for `/`, `/blog/`, `/404`, `/blog/sample-post/`.
- AC3 (CSP allows `plausible.io` on `script-src` AND `connect-src`): shipped. Verified in built HTML.
- AC5 (no cookie banner required): confirmed by inspection — no cookie-setting code, no cookie banner UI; the only `cookie` token in the build output is the word `cookieless` in the documentation comment.
- AC7 (`npm run build` succeeds): ✅ 4 pages built in 915ms.
- AC6 (About page note): explicitly marked out-of-scope in the issue.

## Operator follow-up (outside this PR)
- AC1: create the Plausible site for `how-do-i.ai`.
- AC4: confirm ≥1 page view in the Plausible dashboard after deploy.

## Test plan
- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean (2 pre-existing hints unrelated)
- [x] `npm run test` — 3 files, 23 tests passed
- [x] `npm run build` succeeds; script + CSP verified on all generated pages
- [ ] Post-deploy: operator verifies page view shows in Plausible dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)