### PR TITLE
(refactor) rename pillar slugs to thinking/practice/tools/meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Blog posts live in `src/content/blog/{slug}.md`. Frontmatter is validated by the
 | `readingTime` | no       | Integer minutes; auto-estimated if omitted    |
 | `draft`       | no       | `true` to exclude from build; default `false` |
 
-Valid pillars: `ai-first-thinking`, `ai-in-practice`, `tools-and-workflows`, `behind-the-scenes`.
+Valid pillars: `thinking`, `practice`, `tools`, `meta`.
 
 Valid series: `ai-at-home`, `ai-at-work`, `ai-for-gigs`, `ai-mindset`.
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -9,13 +9,13 @@ interface Props {
 
 const { activePillar } = Astro.props;
 
-const btsPosts = await getPostsByPillar('behind-the-scenes');
-const showBts = btsPosts.length > 0;
+const metaPosts = await getPostsByPillar('meta');
+const showMeta = metaPosts.length > 0;
 
-// Nav surfaces all pillars except Behind-the-Scenes, which only shows
-// once there is at least one published post in that pillar.
+// Nav surfaces all pillars except Meta, which only shows once there
+// is at least one published post in that pillar.
 const pillars = Object.entries(PILLARS)
-  .filter(([slug]) => slug !== 'behind-the-scenes' || showBts)
+  .filter(([slug]) => slug !== 'meta' || showMeta)
   .map(([slug, label]) => ({ slug, label }));
 ---
 

--- a/src/content/blog/sample-post.md
+++ b/src/content/blog/sample-post.md
@@ -2,7 +2,7 @@
 title: 'Building Your First AI-Assisted Workflow'
 description: 'A practical guide to integrating AI tools into your daily work, from identifying repetitive tasks to building reliable automation pipelines.'
 date: 2025-01-15
-pillar: tools-and-workflows
+pillar: tools
 series: ai-at-work
 tags:
   - automation

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -42,7 +42,7 @@ function post(overrides: {
       title: 't',
       description: 'd',
       date: new Date(2025, 0, 1),
-      pillar: 'ai-in-practice',
+      pillar: 'practice',
       tags: [],
       draft: false,
       ...overrides.data,
@@ -86,7 +86,7 @@ describe('getPostsByPillar / getPostsBySeries / getPostsByTag', () => {
       post({
         id: 'p1',
         data: {
-          pillar: 'ai-in-practice',
+          pillar: 'practice',
           series: 'ai-at-work',
           tags: ['llms'],
         },
@@ -94,20 +94,20 @@ describe('getPostsByPillar / getPostsBySeries / getPostsByTag', () => {
       post({
         id: 'p2',
         data: {
-          pillar: 'tools-and-workflows',
+          pillar: 'tools',
           series: 'ai-for-gigs',
           tags: ['ide'],
         },
       }),
       post({
         id: 'p3',
-        data: { pillar: 'ai-in-practice', tags: ['llms', 'rag'] },
+        data: { pillar: 'practice', tags: ['llms', 'rag'] },
       }),
     ]);
   });
 
   it('filters by pillar', async () => {
-    const result = await getPostsByPillar('ai-in-practice');
+    const result = await getPostsByPillar('practice');
     expect(result.map((p) => p.id).sort()).toEqual(['p1', 'p3']);
   });
 
@@ -127,20 +127,20 @@ describe('getRelatedPosts', () => {
     getCollectionMock.mockImplementation(async () => [
       post({
         id: 'current',
-        data: { pillar: 'ai-in-practice', series: 'ai-at-work', tags: ['a'] },
+        data: { pillar: 'practice', series: 'ai-at-work', tags: ['a'] },
       }),
       post({
         id: 'same-pillar-only',
-        data: { pillar: 'ai-in-practice', tags: [] },
+        data: { pillar: 'practice', tags: [] },
       }),
       post({
         id: 'same-series-only',
-        data: { pillar: 'tools-and-workflows', series: 'ai-at-work', tags: [] },
+        data: { pillar: 'tools', series: 'ai-at-work', tags: [] },
       }),
     ]);
     const current = post({
       id: 'current',
-      data: { pillar: 'ai-in-practice', series: 'ai-at-work', tags: ['a'] },
+      data: { pillar: 'practice', series: 'ai-at-work', tags: ['a'] },
     });
     const result = await getRelatedPosts(current, 3);
     expect(result.map((p) => p.id)).toEqual([
@@ -153,20 +153,20 @@ describe('getRelatedPosts', () => {
     getCollectionMock.mockImplementation(async () => [
       post({
         id: 'current',
-        data: { pillar: 'ai-in-practice', tags: ['a', 'b'] },
+        data: { pillar: 'practice', tags: ['a', 'b'] },
       }),
       post({
         id: 'tags-only',
-        data: { pillar: 'behind-the-scenes', tags: ['a', 'b'] },
+        data: { pillar: 'meta', tags: ['a', 'b'] },
       }),
       post({
         id: 'pillar-no-tags',
-        data: { pillar: 'ai-in-practice', tags: [] },
+        data: { pillar: 'practice', tags: [] },
       }),
     ]);
     const current = post({
       id: 'current',
-      data: { pillar: 'ai-in-practice', tags: ['a', 'b'] },
+      data: { pillar: 'practice', tags: ['a', 'b'] },
     });
     const result = await getRelatedPosts(current, 3);
     // pillar-no-tags: score 2 (pillar). tags-only: score 2 (two shared tags).
@@ -179,11 +179,11 @@ describe('getRelatedPosts', () => {
 
   it('excludes the post itself', async () => {
     getCollectionMock.mockImplementation(async () => [
-      post({ id: 'current', data: { pillar: 'ai-in-practice', tags: ['a'] } }),
+      post({ id: 'current', data: { pillar: 'practice', tags: ['a'] } }),
     ]);
     const current = post({
       id: 'current',
-      data: { pillar: 'ai-in-practice', tags: ['a'] },
+      data: { pillar: 'practice', tags: ['a'] },
     });
     const result = await getRelatedPosts(current, 3);
     expect(result).toEqual([]);
@@ -192,10 +192,10 @@ describe('getRelatedPosts', () => {
   it('returns at most `limit` results', async () => {
     getCollectionMock.mockImplementation(async () =>
       [1, 2, 3, 4, 5].map((i) =>
-        post({ id: `p${i}`, data: { pillar: 'ai-in-practice' } }),
+        post({ id: `p${i}`, data: { pillar: 'practice' } }),
       ),
     );
-    const current = post({ id: 'current', data: { pillar: 'ai-in-practice' } });
+    const current = post({ id: 'current', data: { pillar: 'practice' } });
     const result = await getRelatedPosts(current, 2);
     expect(result).toHaveLength(2);
   });
@@ -204,12 +204,12 @@ describe('getRelatedPosts', () => {
     getCollectionMock.mockImplementation(async () => [
       post({
         id: 'unrelated',
-        data: { pillar: 'behind-the-scenes', tags: ['other'] },
+        data: { pillar: 'meta', tags: ['other'] },
       }),
     ]);
     const current = post({
       id: 'current',
-      data: { pillar: 'ai-in-practice', tags: ['rag'] },
+      data: { pillar: 'practice', tags: ['rag'] },
     });
     const result = await getRelatedPosts(current, 3);
     expect(result).toEqual([]);

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -7,10 +7,10 @@
  */
 
 export const PILLARS = {
-  'ai-first-thinking': 'AI-First Thinking',
-  'ai-in-practice': 'AI in Practice',
-  'tools-and-workflows': 'Tools & Workflows',
-  'behind-the-scenes': 'Behind the Scenes',
+  thinking: 'AI-First Thinking',
+  practice: 'AI in Practice',
+  tools: 'Tools & Workflows',
+  meta: 'Meta',
 } as const;
 
 export const SERIES = {


### PR DESCRIPTION
## Summary

Rename the four pillar slugs to the short, voice-aligned names used in the HQ content strategy, before any content is published.

| Old slug              | New slug   |
| --------------------- | ---------- |
| `ai-first-thinking`   | `thinking` |
| `ai-in-practice`      | `practice` |
| `tools-and-workflows` | `tools`    |
| `behind-the-scenes`   | `meta`     |

The fourth pillar's label also changes: **"Behind the Scenes" → "Meta"**, matching `strategy.md`.

## Changes

- **`src/lib/taxonomy.ts`** — PILLARS keys renamed; "Behind the Scenes" → "Meta".
- **`src/content.config.ts`** — unchanged; Zod enum derives from `PILLAR_SLUGS`, updates automatically.
- **`src/content/blog/sample-post.md`** — frontmatter `pillar: tools-and-workflows` → `pillar: tools`.
- **`src/components/Nav.astro`** — slug references + internal variable rename (`btsPosts`/`showBts` → `metaPosts`/`showMeta`); comment updated.
- **`src/lib/posts.test.ts`** — 18 fixture references updated.
- **`README.md`** — valid pillar list updated.

Out of scope (per the issue): pillar hub pages and HQ doc updates in the other repo.

## Test plan

- [x] `npm run typecheck` — 0 errors.
- [x] `npm run test` — 23/23 pass.
- [x] `npm run build` — 4 pages built.
- [x] `npm run lint` + `npm run format:check` — clean.
- [x] `dist/index.html` nav links use `pillar=thinking`, `pillar=practice`, `pillar=tools`.
- [x] `dist/blog/index.html` post card renders `data-pillar="tools"`.
- [x] `meta` pillar correctly gated from nav (no meta-pillared posts yet).
- [x] Repo-wide grep for old slugs and "Behind the Scenes" → 0 matches.

Closes #57