### PR TITLE
(feat) add JSON-LD structured data (Article + Organization + BreadcrumbList)

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,4 +1,6 @@
 ---
+import { buildOrganizationSchema } from '../lib/structured-data';
+
 interface Props {
   title: string;
   description: string;
@@ -20,6 +22,12 @@ const canonicalURL = new URL(
   Astro.site,
 );
 const imageURL = new URL(image, Astro.site);
+
+// Organization JSON-LD is injected site-wide. Per-page schemas (Article,
+// BreadcrumbList) are injected from the page/layout that has the context.
+const organizationSchema = Astro.site
+  ? buildOrganizationSchema(Astro.site)
+  : null;
 ---
 
 <head>
@@ -113,6 +121,24 @@ const imageURL = new URL(image, Astro.site);
     defer
     data-domain="how-do-i.ai"
     src="https://plausible.io/js/script.js"></script>
+
+  {
+    /*
+      Schema.org Organization JSON-LD for SEO + AEO. HDIAI is an Organization,
+      not a Person — no founder attribution. The @id is referenced by
+      per-page Article schemas (publisher, author) to form a connected graph.
+      sameAs[] MUST stay in sync with the channel list in Footer.astro.
+    */
+  }
+  {
+    organizationSchema && (
+      <script
+        type="application/ld+json"
+        is:inline
+        set:html={JSON.stringify(organizationSchema)}
+      />
+    )
+  }
 
   <title>{title}</title>
 </head>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -13,6 +13,10 @@
  */
 
 import TableOfContents from '../components/TableOfContents.astro';
+import {
+  buildArticleSchema,
+  buildBreadcrumbListSchema,
+} from '../lib/structured-data';
 
 interface Props {
   frontmatter: {
@@ -32,7 +36,57 @@ const formattedDate = new Date(frontmatter.date).toLocaleDateString('en-US', {
   month: 'long',
   day: 'numeric',
 });
+
+// Per-post structured data. `Astro.site` is defined in astro.config.mjs and
+// required for absolute URLs; skip schema injection if it's absent.
+const articleSchema = Astro.site
+  ? buildArticleSchema({
+      title: frontmatter.title,
+      description: frontmatter.description,
+      datePublished: new Date(frontmatter.date),
+      url: new URL(Astro.url.pathname, Astro.site),
+      siteUrl: Astro.site,
+      imageUrl: new URL('/brand/og-default.png', Astro.site),
+    })
+  : null;
+
+const breadcrumbSchema = Astro.site
+  ? buildBreadcrumbListSchema([
+      { name: 'Home', url: Astro.site },
+      { name: 'Blog', url: new URL('/blog/', Astro.site) },
+      {
+        name: frontmatter.title,
+        url: new URL(Astro.url.pathname, Astro.site),
+      },
+    ])
+  : null;
 ---
+
+{
+  /*
+    Per-post JSON-LD: Article (headline, date, Organization author/publisher)
+    and BreadcrumbList (Home → Blog → Post). Script tags in <body> are valid
+    and picked up by Google/LLM crawlers the same as those in <head>.
+  */
+}
+{
+  articleSchema && (
+    <script
+      type="application/ld+json"
+      is:inline
+      set:html={JSON.stringify(articleSchema)}
+    />
+  )
+}
+{
+  breadcrumbSchema && (
+    <script
+      type="application/ld+json"
+      is:inline
+      set:html={JSON.stringify(breadcrumbSchema)}
+    />
+  )
+}
 
 <article class="post">
   <header class="post-header">

--- a/src/lib/structured-data.test.ts
+++ b/src/lib/structured-data.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildOrganizationSchema,
+  buildArticleSchema,
+  buildBreadcrumbListSchema,
+  ORGANIZATION_SAME_AS,
+} from './structured-data';
+
+const SITE_URL = new URL('https://how-do-i.ai/');
+
+describe('buildOrganizationSchema', () => {
+  it('returns a valid Organization schema with required fields', () => {
+    const schema = buildOrganizationSchema(SITE_URL);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('Organization');
+    expect(schema.name).toBe('How Do I AI');
+    expect(schema.url).toBe('https://how-do-i.ai/');
+  });
+
+  it('uses a stable @id fragment on the site URL', () => {
+    const schema = buildOrganizationSchema(SITE_URL);
+    expect(schema['@id']).toBe('https://how-do-i.ai/#organization');
+  });
+
+  it('resolves logo to an absolute URL meeting Google minimum size', () => {
+    const schema = buildOrganizationSchema(SITE_URL);
+    expect(schema.logo.url).toBe(
+      'https://how-do-i.ai/brand/apple-touch-icon.png',
+    );
+    expect(schema.logo.width).toBeGreaterThanOrEqual(112);
+    expect(schema.logo.height).toBeGreaterThanOrEqual(112);
+  });
+
+  it('includes all 8 HDIAI social channels in sameAs[]', () => {
+    const schema = buildOrganizationSchema(SITE_URL);
+    expect(schema.sameAs).toHaveLength(8);
+    expect(schema.sameAs).toEqual(ORGANIZATION_SAME_AS);
+  });
+
+  it('locks the canonical channel URL set (in sync with Footer.astro)', () => {
+    expect(ORGANIZATION_SAME_AS).toEqual([
+      'https://www.youtube.com/@Learn.How-Do-I-AI',
+      'https://www.linkedin.com/company/how-do-i-ai/',
+      'https://www.instagram.com/how_do_i_ai/',
+      'https://www.tiktok.com/@how_do_i_ai',
+      'https://www.threads.com/@how_do_i_ai',
+      'https://bsky.app/profile/how-do-i.ai',
+      'https://www.facebook.com/How.Do.I.AI.blog',
+      'https://x.com/how_do_i_ai',
+    ]);
+  });
+});
+
+describe('buildArticleSchema', () => {
+  const baseInput = {
+    title: 'Sample Post',
+    description: 'A test article.',
+    datePublished: new Date('2025-01-15T00:00:00Z'),
+    url: new URL('https://how-do-i.ai/blog/sample-post/'),
+    siteUrl: SITE_URL,
+    imageUrl: new URL('https://how-do-i.ai/brand/og-default.png'),
+  };
+
+  it('returns a valid Article schema with required fields', () => {
+    const schema = buildArticleSchema(baseInput);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('Article');
+    expect(schema.headline).toBe('Sample Post');
+    expect(schema.description).toBe('A test article.');
+    expect(schema.datePublished).toBe('2025-01-15T00:00:00.000Z');
+    expect(schema.image).toBe('https://how-do-i.ai/brand/og-default.png');
+  });
+
+  it('attributes author to the Organization, NOT a Person', () => {
+    const schema = buildArticleSchema(baseInput);
+    expect(schema.author['@type']).toBe('Organization');
+    expect(schema.author['@id']).toBe('https://how-do-i.ai/#organization');
+  });
+
+  it('attributes publisher to the Organization, NOT a Person', () => {
+    const schema = buildArticleSchema(baseInput);
+    expect(schema.publisher['@type']).toBe('Organization');
+    expect(schema.publisher['@id']).toBe('https://how-do-i.ai/#organization');
+  });
+
+  it('sets mainEntityOfPage to the absolute post URL', () => {
+    const schema = buildArticleSchema(baseInput);
+    expect(schema.mainEntityOfPage['@type']).toBe('WebPage');
+    expect(schema.mainEntityOfPage['@id']).toBe(
+      'https://how-do-i.ai/blog/sample-post/',
+    );
+  });
+
+  it('omits dateModified when not provided', () => {
+    const schema = buildArticleSchema(baseInput);
+    expect(schema.dateModified).toBeUndefined();
+  });
+
+  it('omits dateModified when equal to datePublished', () => {
+    const schema = buildArticleSchema({
+      ...baseInput,
+      dateModified: new Date('2025-01-15T00:00:00Z'),
+    });
+    expect(schema.dateModified).toBeUndefined();
+  });
+
+  it('includes dateModified when different from datePublished', () => {
+    const schema = buildArticleSchema({
+      ...baseInput,
+      dateModified: new Date('2025-03-01T00:00:00Z'),
+    });
+    expect(schema.dateModified).toBe('2025-03-01T00:00:00.000Z');
+  });
+});
+
+describe('buildBreadcrumbListSchema', () => {
+  it('returns a valid BreadcrumbList schema', () => {
+    const schema = buildBreadcrumbListSchema([
+      { name: 'Home', url: new URL('https://how-do-i.ai/') },
+      { name: 'Blog', url: new URL('https://how-do-i.ai/blog/') },
+      { name: 'Sample', url: new URL('https://how-do-i.ai/blog/sample/') },
+    ]);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('BreadcrumbList');
+    expect(schema.itemListElement).toHaveLength(3);
+  });
+
+  it('assigns 1-based positions to items in order', () => {
+    const schema = buildBreadcrumbListSchema([
+      { name: 'Home', url: new URL('https://how-do-i.ai/') },
+      { name: 'Blog', url: new URL('https://how-do-i.ai/blog/') },
+      { name: 'Sample', url: new URL('https://how-do-i.ai/blog/sample/') },
+    ]);
+    expect(schema.itemListElement[0].position).toBe(1);
+    expect(schema.itemListElement[1].position).toBe(2);
+    expect(schema.itemListElement[2].position).toBe(3);
+  });
+
+  it('renders item URLs as absolute strings', () => {
+    const schema = buildBreadcrumbListSchema([
+      { name: 'Home', url: new URL('https://how-do-i.ai/') },
+      { name: 'Blog', url: new URL('https://how-do-i.ai/blog/') },
+    ]);
+    expect(schema.itemListElement[0].item).toBe('https://how-do-i.ai/');
+    expect(schema.itemListElement[1].item).toBe('https://how-do-i.ai/blog/');
+  });
+});

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,163 @@
+/**
+ * Schema.org JSON-LD builders for SEO + AEO (answer-engine optimization).
+ *
+ * Three schemas are load-bearing for this site:
+ *   - Organization: site-wide, injected in BaseHead
+ *   - Article:      per blog post, injected in BlogPostLayout
+ *   - BreadcrumbList: per blog post, injected in BlogPostLayout
+ *
+ * HDIAI is an Organization, not a Person. Author and publisher always
+ * reference the Organization @id — no personal/founder attribution.
+ */
+
+/**
+ * Stable @id fragment for the HDIAI Organization. Referenced from Article
+ * publisher/author so the schema graph stays connected across pages.
+ */
+export const ORGANIZATION_ID_FRAGMENT = '#organization';
+
+/**
+ * Social channel URLs for Organization `sameAs[]`.
+ *
+ * MUST match the channel list in `src/components/Footer.astro`. If a channel
+ * is added or removed there, update this list too. The structured-data test
+ * locks the expected set.
+ */
+export const ORGANIZATION_SAME_AS: readonly string[] = [
+  'https://www.youtube.com/@Learn.How-Do-I-AI',
+  'https://www.linkedin.com/company/how-do-i-ai/',
+  'https://www.instagram.com/how_do_i_ai/',
+  'https://www.tiktok.com/@how_do_i_ai',
+  'https://www.threads.com/@how_do_i_ai',
+  'https://bsky.app/profile/how-do-i.ai',
+  'https://www.facebook.com/How.Do.I.AI.blog',
+  'https://x.com/how_do_i_ai',
+] as const;
+
+/**
+ * Organization logo: a raster image ≥112x112 per Google's guidance.
+ * `apple-touch-icon.png` is 200x200 and already shipped.
+ */
+const ORGANIZATION_LOGO_PATH = '/brand/apple-touch-icon.png';
+
+export interface OrganizationSchema {
+  '@context': 'https://schema.org';
+  '@type': 'Organization';
+  '@id': string;
+  name: string;
+  alternateName?: string;
+  url: string;
+  logo: {
+    '@type': 'ImageObject';
+    url: string;
+    width: number;
+    height: number;
+  };
+  sameAs: readonly string[];
+}
+
+export function buildOrganizationSchema(siteUrl: URL): OrganizationSchema {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': new URL(ORGANIZATION_ID_FRAGMENT, siteUrl).href,
+    name: 'How Do I AI',
+    alternateName: 'HDIAI',
+    url: siteUrl.href,
+    logo: {
+      '@type': 'ImageObject',
+      url: new URL(ORGANIZATION_LOGO_PATH, siteUrl).href,
+      width: 200,
+      height: 200,
+    },
+    sameAs: ORGANIZATION_SAME_AS,
+  };
+}
+
+export interface ArticleSchemaInput {
+  title: string;
+  description: string;
+  datePublished: Date;
+  dateModified?: Date;
+  url: URL;
+  siteUrl: URL;
+  imageUrl: URL;
+}
+
+export interface ArticleSchema {
+  '@context': 'https://schema.org';
+  '@type': 'Article';
+  headline: string;
+  description: string;
+  datePublished: string;
+  dateModified?: string;
+  author: { '@type': 'Organization'; '@id': string };
+  publisher: { '@type': 'Organization'; '@id': string };
+  image: string;
+  mainEntityOfPage: {
+    '@type': 'WebPage';
+    '@id': string;
+  };
+}
+
+export function buildArticleSchema(input: ArticleSchemaInput): ArticleSchema {
+  const organizationRef = {
+    '@type': 'Organization' as const,
+    '@id': new URL(ORGANIZATION_ID_FRAGMENT, input.siteUrl).href,
+  };
+
+  const schema: ArticleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: input.title,
+    description: input.description,
+    datePublished: input.datePublished.toISOString(),
+    author: organizationRef,
+    publisher: organizationRef,
+    image: input.imageUrl.href,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': input.url.href,
+    },
+  };
+
+  if (
+    input.dateModified &&
+    input.dateModified.getTime() !== input.datePublished.getTime()
+  ) {
+    schema.dateModified = input.dateModified.toISOString();
+  }
+
+  return schema;
+}
+
+export interface BreadcrumbItem {
+  name: string;
+  url: URL;
+}
+
+export interface BreadcrumbListSchema {
+  '@context': 'https://schema.org';
+  '@type': 'BreadcrumbList';
+  itemListElement: {
+    '@type': 'ListItem';
+    position: number;
+    name: string;
+    item: string;
+  }[];
+}
+
+export function buildBreadcrumbListSchema(
+  items: BreadcrumbItem[],
+): BreadcrumbListSchema {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url.href,
+    })),
+  };
+}


### PR DESCRIPTION
Closes #63.

## Summary

Adds three schema.org JSON-LD schemas for SEO + AEO (answer-engine optimization):

- **Organization** — injected site-wide via `BaseHead.astro` (every page). Uses a stable `@id` (`https://how-do-i.ai/#organization`) that Article publisher/author reference, forming a connected graph. `sameAs[]` mirrors the 8 social channels in `Footer.astro` (YouTube, LinkedIn, Instagram, TikTok, Threads, Bluesky, Facebook, X).
- **Article** — injected per blog post via `BlogPostLayout.astro`. Includes `headline`, `description`, `datePublished`, `author` (Organization @id), `publisher` (Organization @id), `image`, `mainEntityOfPage`. `dateModified` is emitted only when different from `datePublished`.
- **BreadcrumbList** — injected per blog post. Three levels: Home → Blog → Post Title. 1-based positions.

HDIAI is an **Organization**, not a Person — no founder or personal attribution anywhere in the schemas (locked by unit test).

## Changes

- `src/lib/structured-data.ts` (new) — typed builders `buildOrganizationSchema`, `buildArticleSchema`, `buildBreadcrumbListSchema`, plus `ORGANIZATION_SAME_AS` constant.
- `src/lib/structured-data.test.ts` (new) — 15 unit tests that lock invariants: no Person refs, Organization ref consistency, sameAs[] URL set in sync with Footer.astro, 1-based breadcrumb positions, dateModified omission logic.
- `src/components/BaseHead.astro` — imports `buildOrganizationSchema`, emits `<script type="application/ld+json">` site-wide (guarded by `Astro.site`).
- `src/layouts/BlogPostLayout.astro` — imports Article + BreadcrumbList builders, emits two scripts per post using `Astro.url` + `Astro.site`.

CSP is unchanged — the existing `script-src 'unsafe-inline'` already covered inline JSON-LD.

## Out of scope

- `HowTo` / `FAQPage` schemas (defer until content justifies them).
- Per-post author override (there is no per-post author; see AC).
- Video schema.

## Test plan

- [x] `npm run typecheck` → 0 errors, 0 warnings.
- [x] `npm run lint` → clean.
- [x] `npm run test` → 38 passed (15 new).
- [x] `npm run build` → 5 pages built, no errors.
- [x] Runtime inspection (`node` parse) — 4/4 pages emit exactly 1 Organization schema; blog post page emits 3 schemas (Organization + Article + BreadcrumbList), all parse as valid JSON. `grep Person` on built HTML returns 0 — no Person attribution leaks.
- [ ] **Post-deploy**: verify at https://search.google.com/test/rich-results and https://validator.schema.org/ on a live preview or production URL (AC requirement; cannot be automated offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)