### PR TITLE
(feat) add llms.txt and robots.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,19 @@
+# How Do I AI?
+
+> AI first. For all of it. — https://how-do-i.ai
+
+How Do I AI? is a publication, not a personal brand. Multi-format content — blog, video, podcast — about applying AI to real work: drafting, planning, household logistics, side gigs, creative projects, shipping code. Practitioner walkthroughs with real workflows, real results, and the parts that didn't work. No "Top 10 Tools" lists. No courses to sell. No "AI will change everything" hype. AI writes. A human decides what's true.
+
+## Core
+
+- [About](https://how-do-i.ai/about/): What How Do I AI? is, how it's made, and why it isn't attributed to a person — a question brand, not a personal brand.
+- [Blog](https://how-do-i.ai/blog/): All posts, filterable by pillar, series, or tag.
+- [RSS feed](https://how-do-i.ai/rss.xml): Subscribe to new posts.
+- [Sitemap](https://how-do-i.ai/sitemap-index.xml): Full URL index.
+
+## Pillars
+
+- [AI-First Thinking](https://how-do-i.ai/blog/?pillar=thinking): Mental models, the Default Question, editorial position — starting with "how would I do this if AI could do anything?" instead of "can AI help?".
+- [AI in Practice](https://how-do-i.ai/blog/?pillar=practice): Practitioner walkthroughs — real workflows applied to real work, including the parts that didn't work.
+- [Tools & Workflows](https://how-do-i.ai/blog/?pillar=tools): Tool assessments, integrations, and repeatable workflows. Honest takes — not neutral.
+- [Meta](https://how-do-i.ai/blog/?pillar=meta): About the publication itself — how it's made, editorial standards, the AI-first production process.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+# How Do I AI? — robots.txt
+# Policy: all user-agents may index the full site, including AI crawlers.
+# LLM citation is a core distribution channel; AI bots are welcome.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://how-do-i.ai/sitemap-index.xml


### PR DESCRIPTION
## Summary

- Adds `public/llms.txt` per the [llmstxt.org](https://llmstxt.org/) convention — H1, tagline blockquote + URL, voice-matched brand paragraph, Core + Pillars link sections. LLM crawlers now have a canonical brand/content summary.
- Adds `public/robots.txt` explicitly. Astro's sitemap integration does NOT auto-generate one (confirmed: `dist/` only contains `sitemap-index.xml` + `sitemap-0.xml`). Allows all user-agents, points to the sitemap, does NOT disallow AI crawlers (GPTBot, ClaudeBot, etc.) — LLM citation is a core distribution channel.

Pillar links use the `/blog/?pillar={slug}` filter URL pattern with post-rename slugs (`thinking`, `practice`, `tools`, `meta`) from `src/lib/taxonomy.ts`.

## Test plan

- [x] `npm run build` succeeds — both files emitted to `dist/` root
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run typecheck` — no new errors (2 pre-existing hints in `BlogFilter.astro` unchanged)
- [x] `npm run test` — 23/23 passing
- [x] Validated each AC adversarially in fresh-context subclaude — all 12 PASS
- [x] Polished via fresh-context subclaude — CLEAN ENOUGH (one stylistic em-dash fix applied)
- [ ] Post-merge: verify `https://how-do-i.ai/llms.txt` and `https://how-do-i.ai/robots.txt` reachable

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)