### PR TITLE
(docs) add CONTRIBUTING.md with HQ cross-repo setup + asset provenance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for your interest in How Do I AI. This doc covers the repo-level conventions that are not obvious from reading the code.
+
+For dev setup (Node, `npm install`, `npm run dev`/`build`/`preview`) see the [README](./README.md).
+
+## Cross-repo setup
+
+The HDIAI brand is split across two repos:
+
+- **This repo** (`how-do-i-ai/how-do-i-ai.github.io`, public) — the Astro site served at [how-do-i.ai](https://how-do-i.ai).
+- **HDIAI HQ repo** (private) — brand, content, and strategy HQ: source-of-truth brand assets (logo SVGs, social/OG images, identity and messaging docs), content strategy, and decision records (ADR / PDR).
+
+### Local layout
+
+The convention is to clone HQ as a **sibling directory** of this repo:
+
+```
+<workspace>/
+├── how-do-i-ai.github.io/   ← this repo
+└── hq/                      ← HDIAI HQ (private)
+```
+
+Paths in issue descriptions and commit messages that look like `hq/brand/...` or `../hq/brand/...` refer to this sibling layout. Any local layout works as long as you know where HQ is — the sibling convention just makes those references resolvable without adjustment.
+
+### HQ is private
+
+The HQ repo is not publicly accessible. Issue descriptions, ADR/PDR references, and asset provenance notes in this repo may reference `hq/*` paths — those references are for **provenance and audit**, not click-through navigation. Contributors who need the referenced material must arrange access to the HQ repo separately.
+
+Issues that reference HQ paths should include a short note near the top so new contributors can resolve the reference. The convention is:
+
+> _This issue references files in the HDIAI HQ repo (private). See [`CONTRIBUTING.md` § Cross-repo setup](./CONTRIBUTING.md#cross-repo-setup). Contributors need to arrange HQ access separately._
+
+## Vendored brand assets
+
+Brand assets consumed by the site (favicons, OG image, logo marks) live under `public/brand/`. They are **copied in** from the HQ repo — not symlinked, not pulled at build time, not regenerated in CI. The binaries in `public/brand/` are the deliverable; this repo is self-contained at build time and needs no HQ access to build.
+
+### Provenance: `public/brand/SOURCE.md`
+
+Every file under `public/brand/` is listed in [`public/brand/SOURCE.md`](./public/brand/SOURCE.md) with:
+
+- its path within `public/brand/`,
+- its HQ origin path (where the source-of-truth lives in the HQ repo),
+- its last-synced date (when it was last re-vendored into this repo).
+
+Keeping `SOURCE.md` accurate is part of the vendoring step — if you update an asset without updating `SOURCE.md`, future contributors will have no way to trace the binary back to its source.
+
+### Update workflow
+
+When HQ ships a new brand release or you need to re-vendor an asset:
+
+1. **Re-render or pull** the finalized asset from HQ (not from an intermediate draft).
+2. **Copy** the binary into `public/brand/`, overwriting the existing file. Keep the filename stable so `BaseHead.astro` and friends don't need to change.
+3. **Update `public/brand/SOURCE.md`**: verify the HQ origin path still matches, and bump the last-synced date to today. Add a row if the asset is new.
+4. **Commit** with a subject like `(feat) replace {asset} with {release-name}` or `(chore) re-vendor {asset} from HQ`, referencing the HQ release when relevant.
+
+No automation, no symlink, no build-time fetch: vendored means vendored. Automation can come later once cadence justifies it.
+
+## Branches, commits, and pull requests
+
+- **Branch names**: `{type}/{issue-number}-{short-slug}` (e.g., `feat/63-jsonld-structured-data`, `docs/76-hq-cross-repo-setup`).
+- **Commit subjects**: `(type) imperative lowercase description` (e.g., `(docs) add CONTRIBUTING`, `(feat) replace placeholder OG with Pass-2 brand image`). Types in use: `feat`, `fix`, `docs`, `chore`, `refactor`.
+- **Pull requests** target `main`. The repo is rebase-merge only, so keep the branch history tidy — it will land on `main` as-is.
+- **CI** runs on every push and PR (`.github/workflows/ci.yml`): security audit (`npm audit --omit=dev`), lint, typecheck, test, build. All must pass before merge.
+- **Deployment** to GitHub Pages runs automatically on push to `main` via `.github/workflows/deploy.yml`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Drafts (`draft: true`) are excluded from listings, RSS, sitemap, and page genera
 
 GitHub Pages via `.github/workflows/deploy.yml`. Triggered on push to `main`. The workflow builds the site and publishes `dist/` to the `gh-pages` environment.
 
+## Contributing
+
+Repo conventions — cross-repo setup (the private HDIAI HQ sibling repo), vendored brand asset provenance, branch and commit style — live in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
 ## License
 
 See [LICENSE](./LICENSE) for the project license. Self-hosted fonts carry their own licenses — see attribution files alongside the font binaries in `public/fonts/`.

--- a/public/brand/SOURCE.md
+++ b/public/brand/SOURCE.md
@@ -28,9 +28,9 @@ page does not set its own `image` prop. Embedded as `og:image` and
 `twitter:image`; renders in link previews on LinkedIn, Slack, Discord,
 iMessage, WhatsApp, Twitter, Bluesky, and similar surfaces.
 
-| File in `public/brand/` | HQ origin (brand HQ)          | Last synced |
-| ----------------------- | ----------------------------- | ----------- |
-| `og-default.png`        | `brand/social/og-image/*.svg` | 2026-04-18  |
+| File in `public/brand/` | HQ origin (brand HQ)                 | Last synced |
+| ----------------------- | ------------------------------------ | ----------- |
+| `og-default.png`        | `brand/social/og-image/og-image.svg` | 2026-04-18  |
 
 - Dimensions: 1200×630 (standard OG aspect)
 - Composition: Signal Orange (`#E85D2A`) base, two-line tagline in Inter 800,

--- a/public/brand/SOURCE.md
+++ b/public/brand/SOURCE.md
@@ -6,14 +6,17 @@ private brand HQ, maintained alongside this repo in the development
 workspace. Do not edit the binaries in this directory — rebuild them
 from the brand HQ and copy the result back.
 
+For the full cross-repo setup convention (HQ is a private sibling repo)
+and the update workflow, see [`CONTRIBUTING.md` § Cross-repo setup](../../CONTRIBUTING.md#cross-repo-setup).
+
 ## Favicon + touch icon
 
-| File in `public/brand/` | HQ origin (brand HQ)              |
-| ----------------------- | --------------------------------- |
-| `favicon.svg`           | `logo/svg/square-mono.svg`        |
-| `favicon-32.png`        | `logo/png/square-mono/32.png`     |
-| `favicon-48.png`        | `logo/png/square-mono/48.png`     |
-| `apple-touch-icon.png`  | `logo/png/square-light-bg/200.png`|
+| File in `public/brand/` | HQ origin (brand HQ)               | Last synced |
+| ----------------------- | ---------------------------------- | ----------- |
+| `favicon.svg`           | `logo/svg/square-mono.svg`         | 2026-04-18  |
+| `favicon-32.png`        | `logo/png/square-mono/32.png`      | 2026-04-18  |
+| `favicon-48.png`        | `logo/png/square-mono/48.png`      | 2026-04-18  |
+| `apple-touch-icon.png`  | `logo/png/square-light-bg/200.png` | 2026-04-18  |
 
 The iOS touch icon uses the light-background variant so the `Ai?` mark sits
 on an opaque tile rather than showing through to the user's wallpaper.
@@ -25,8 +28,12 @@ page does not set its own `image` prop. Embedded as `og:image` and
 `twitter:image`; renders in link previews on LinkedIn, Slack, Discord,
 iMessage, WhatsApp, Twitter, Bluesky, and similar surfaces.
 
+| File in `public/brand/` | HQ origin (brand HQ)          | Last synced |
+| ----------------------- | ----------------------------- | ----------- |
+| `og-default.png`        | `brand/social/og-image/*.svg` | 2026-04-18  |
+
 - Dimensions: 1200×630 (standard OG aspect)
 - Composition: Signal Orange (`#E85D2A`) base, two-line tagline in Inter 800,
   `how-do-i.ai` in JetBrains Mono, circular logo chip bottom-right
-- Source of truth: `og-image.svg` in the brand HQ (`brand/social/og-image/`)
-- Rebuild: render the SVG to a 1200×630 PNG and copy it to this path
+- Rebuild: render the HQ SVG source to a 1200×630 PNG and copy it to this path,
+  then bump the "Last synced" date above


### PR DESCRIPTION
Closes #76.

## Summary

Documents the HDIAI cross-repo convention (public website ↔ private HQ) and the vendored-asset provenance pattern, so new contributors can resolve `hq/*` references in issue descriptions without implicit context.

## Changes

- **NEW** `CONTRIBUTING.md` at repo root:
  - § Cross-repo setup: two-repo topology, sibling local layout (`../hq/`), HQ-is-private note, issue-description convention for future work that references HQ paths.
  - § Vendored brand assets: binaries under `public/brand/` are copied in, not symlinked / not pulled at build / not regenerated in CI.
  - § Provenance + update workflow: re-render → copy → update `SOURCE.md` → commit.
  - § Branches, commits, PRs: naming, subjects, rebase-only merge, CI gates, deploy workflow.
- **MODIFIED** `public/brand/SOURCE.md`: `Last synced` column added to all five vendored assets; cross-link up to `CONTRIBUTING.md § Cross-repo setup`. Existing preface + composition notes preserved.
- **MODIFIED** `README.md`: one-line pointer to `CONTRIBUTING.md` under a new `Contributing` section.

## Acceptance criteria

- [x] Two-repo topology documented with one-sentence role each (`CONTRIBUTING.md § Cross-repo setup`)
- [x] Local layout: HQ as sibling (`../hq/`); HQ is private, contributors arrange access separately
- [x] Vendored-asset convention: copied in, not symlinked/built
- [x] Provenance pattern: `SOURCE.md` with HQ origin path + last-synced date for every asset
- [x] Update workflow documented
- [x] `public/brand/SOURCE.md` covers all 5 vendored binaries (4 favicon variants + `og-default.png`)
- [x] Repo setup note convention for future issues (`CONTRIBUTING.md § HQ is private` blockquote)
- [x] `README.md` one-line pointer to `CONTRIBUTING.md`
- [x] `npm run build` still succeeds

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npm run test` — 38 passed (4 files)
- [x] `npm run build` — Complete (5 pages built)
- [x] `npx prettier --check .` — clean
- [x] `ls public/brand/` cross-checked against `SOURCE.md` tables — all 5 binaries present