### PR TITLE
(feat) apply PDR-004 tagline system to homepage + Orange Accent Pattern

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -98,7 +98,7 @@ const organizationSchema = Astro.site
   />
 
   <!-- Global styles -->
-  <style>
+  <style is:global>
     @import '../styles/global.css';
   </style>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,8 +16,16 @@ const hasPosts = posts.length > 0;
     <h1 class="hero-brand">
       How Do I AI<span class="hero-question-mark">?</span>
     </h1>
-    <p class="hero-tagline">AI first. For all of it.</p>
-    <p class="hero-descriptor">Real workflows. Honest takes. No hype.</p>
+    <p class="hero-tagline">
+      <span class="accent">AI</span> first –
+      <span class="accent">for</span> everything
+      <span class="accent">you</span> do.
+    </p>
+    <p class="hero-descriptor">
+      What works<span class="accent">?</span>
+      When to use<span class="accent">?</span>
+      How to do<span class="accent">?</span>
+    </p>
   </section>
 
   {
@@ -73,13 +81,15 @@ const hasPosts = posts.length > 0;
 
   .hero-tagline {
     font-size: var(--text-xl);
-    color: var(--color-muted);
+    font-weight: 800;
+    color: var(--color-text);
     margin-block: var(--space-4) var(--space-2);
   }
 
   .hero-descriptor {
     font-size: var(--text-base);
-    color: var(--color-muted);
+    font-weight: 600;
+    color: var(--color-text);
     margin-block: 0;
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -275,3 +275,14 @@ pre code {
   white-space: nowrap;
   border-width: 0;
 }
+
+/* --------------------------------------------------------------------------
+   Utility: Orange Accent Pattern — glyph-level emphasis
+   Wrap the structural anchor of a phrase (word or punctuation) to mark it
+   orange. Honors dark/light mode via --color-accent; no hardcoded hex.
+   Decorative emphasis only — full phrase remains DOM text for a11y.
+   -------------------------------------------------------------------------- */
+
+.accent {
+  color: var(--color-accent);
+}


### PR DESCRIPTION
## Summary

Applies the locked tagline system (PDR-004, 2026-04-17) and introduces the Orange Accent Pattern on the homepage hero.

- **Primary tagline**: `AI first – for everything you do.` — en-dash U+2013 with surrounding spaces, lowercase `for`, period at end; orange accent on the structural anchors **AI** / **for** / **you**.
- **Descriptor**: `What works? When to use? How to do?` — orange accent on all three `?` glyphs.
- **Typography**: Inter 800 (primary) / Inter 600 (descriptor); neutral color switched from `--color-muted` to `--color-text` per PDR-004.
- **New `.accent` utility** in `src/styles/global.css` — a one-declaration class (`color: var(--color-accent)`) that honors light/dark via the existing design tokens. Reusable across future surfaces (pull quotes, H1 accents) without copy-paste, per AC.

## Files touched

- `src/pages/index.astro` — hero tagline + descriptor text, accent spans, font weights, color token.
- `src/styles/global.css` — new `.accent` utility class with doc comment.
- `src/components/BaseHead.astro` — `<style>` → `<style is:global>` on the `global.css` `@import`.

### Note on the `BaseHead.astro` change

The existing `<style>@import '../styles/global.css';</style>` was scoping **all class selectors** in `global.css` to BaseHead's component id, so `.accent` and even the pre-existing `.sr-only` never actually applied. Switching to `<style is:global>` is the minimal correct fix and is necessary for AC3 (reusable CSS class) and AC4 (accent color honors dark/light) to hold on the homepage. Side effect: bundled CSS shrank from 9085 → 7923 bytes (−13%) because redundant scoped selectors collapsed into single global rules. Component-level styles (`.hero-brand`, `.prose h1`, `.pillar-link.active`, …) retain higher specificity and still win — verified in the built CSS.

## Out of scope (per issue)

- Footer tagline and `BaseLayout description` prop still carry the old tagline — deferred to #75 (site-wide copy audit).
- Orange Accent Pattern on headlines / pull quotes / body emphasis — deferred until a usage guide exists.
- 404 page and RSS feed copy — covered by #75.
- OG image regeneration — shipped separately in #59.

## Test plan

- [x] `npm run lint` → clean.
- [x] `npm run typecheck` → 0 errors, 0 warnings (2 pre-existing hints in unrelated files — `eslint.config.js`, `BlogFilter.astro`).
- [x] `npm run test` → 38/38 pass.
- [x] `npm run build` → 5 pages built, no errors.
- [x] `npm run format:check` → clean for this PR (only pre-existing `public/brand/SOURCE.md` drift from 4a7e4fb).
- [x] Built `dist/index.html` tagline text is exactly `AI first – for everything you do.` (en-dash verified as U+2013 via hex dump) and descriptor is exactly `What works? When to use? How to do?`.
- [x] Exactly 6 `class="accent"` spans rendered on the homepage (3 on tagline, 3 on descriptor); 0 accent spans on other pages.
- [x] Built CSS contains **un-scoped** `.accent{color:var(--color-accent)}` (no `[data-astro-cid-...]` attribute — reachable from anywhere).
- [x] Adversarial validation via fresh-context subclaude → verdict CLEAN (all 7 AC PASS, AC6 PARTIAL on decorative-contrast edge case defensible under WCAG 1.4.1).
- [x] Constructive polish via fresh-context subclaude → verdict CLEAN ENOUGH (minor Prettier reformat applied; rendered text verified identical).
- [x] `src/components/Nav.astro` **untouched** — respects the concurrent track working on #74.
- [ ] PR reviewer: visual eyes-on-pixels check in both light + dark modes to confirm the accent words read as intended emphasis without color noise.

Closes #73