### PR TITLE
(chore) refresh non-hero copy + propagate PDR-004 tagline

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # How Do I AI?
 
-> AI first. For all of it. — https://how-do-i.ai
+> AI first – for everything you do. — https://how-do-i.ai
 
 How Do I AI? is a publication, not a personal brand. Multi-format content — blog, video, podcast — about applying AI to real work: drafting, planning, household logistics, side gigs, creative projects, shipping code. Practitioner walkthroughs with real workflows, real results, and the parts that didn't work. No "Top 10 Tools" lists. No courses to sell. No "AI will change everything" hype. AI writes. A human decides what's true.
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -53,7 +53,7 @@ const channels: Channel[] = [
 
 <footer class="site-footer">
   <div class="footer-inner">
-    <p class="tagline">AI first. For all of it.</p>
+    <p class="tagline">AI first – for everything you do.</p>
     <nav class="footer-primary" aria-label="Site">
       <a href="/about/" class="footer-link">About</a>
     </nav>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,13 +4,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout
   title="Page not found — How Do I AI"
-  description="The page you are looking for does not exist."
+  description="That page isn't on How Do I AI — it may have moved, or it never existed."
 >
   <section class="not-found">
     <p class="not-found-code">404</p>
     <h1>Page not found</h1>
     <p class="not-found-message">
-      Sorry, the page you are looking for doesn't exist or has been moved.
+      This page isn't here. It may have moved, or it never existed.
     </p>
     <a href="/" class="not-found-link">&larr; Back to home</a>
   </section>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,14 +9,12 @@ const posts = await getPublishedPosts();
 
 <BaseLayout
   title="Blog — How Do I AI"
-  description="All posts from How Do I AI, sorted by date. Filter by pillar, series, or tag."
+  description="Every post from How Do I AI — practitioner walkthroughs on applying AI to real work. Filter by pillar, series, or tag."
 >
   <section class="blog-index">
     <div class="blog-header">
       <h1>Blog</h1>
-      <p class="blog-subtitle">
-        Explore all posts — filter by pillar, series, or tag.
-      </p>
+      <p class="blog-subtitle">All posts — filter by pillar, series, or tag.</p>
     </div>
 
     <BlogFilter>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,10 @@ const showRecentGrid = recentPosts.length >= 2;
 const hasPosts = posts.length > 0;
 ---
 
-<BaseLayout title="How Do I AI" description="AI first. For all of it.">
+<BaseLayout
+  title="How Do I AI"
+  description="AI first – for everything you do. Practitioner walkthroughs, tool assessments, and the parts that didn't work."
+>
   <section class="hero" aria-label="Introduction">
     <h1 class="hero-brand">
       How Do I AI<span class="hero-question-mark">?</span>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -7,7 +7,8 @@ export async function GET(context: APIContext) {
 
   return rss({
     title: 'How Do I AI',
-    description: 'AI first. For all of it.',
+    description:
+      'AI first – for everything you do. Practitioner walkthroughs and tool assessments from How Do I AI.',
     site: context.site!.href,
     items: posts.map((post) => ({
       title: post.data.title,


### PR DESCRIPTION
## Summary

Site-wide copy audit for #75. Propagates the locked PDR-004 tagline (`AI first – for everything you do.`, en-dash U+2013) into the non-hero surfaces that still carried the old `AI first. For all of it.`, and refreshes 404 + blog-index micro-copy to match the brand-voice gate.

The hero tagline, descriptor, and `.accent` spans on `src/pages/index.astro` are **untouched** — those are #73/#79's scope.

## Changes

| File | Change |
|---|---|
| `public/llms.txt` | Tagline blockquote line → new PDR-004 tagline. En-dash (U+2013) inside the tagline; em-dash (U+2014) preserved as separator between tagline and URL. |
| `src/components/Footer.astro` | `.tagline` text `AI first. For all of it.` → `AI first – for everything you do.`. (#79's out-of-scope note deferred this to #75.) |
| `src/pages/404.astro` | Meta description + on-page `.not-found-message` rewritten. "Sorry, the page you are looking for doesn't exist or has been moved." → "This page isn't here. It may have moved, or it never existed." Title, h1, back-link kept. |
| `src/pages/blog/index.astro` | Meta description sharpened with practitioner positioning. Subtitle `Explore all posts — …` → `All posts — …` (the hedgy verb went). |
| `src/pages/index.astro` | BaseLayout `description` prop (the homepage meta description) → `AI first – for everything you do. Practitioner walkthroughs, tool assessments, and the parts that didn't work.`. **Only line 14 (the prop) — hero content at lines 19-31 untouched.** |
| `src/pages/rss.xml.ts` | RSS feed `description` `AI first. For all of it.` → `AI first – for everything you do. Practitioner walkthroughs and tool assessments from How Do I AI.`. |

## Surfaces reviewed and kept (already voice-matching)

- Home page section headings "Latest" / "Recent"; CTA "See all posts →".
- Blog post page: title format `${title} | How Do I AI`; delegates meta description to per-post frontmatter (correct design).
- `src/components/PrevNextNav.astro`: "← Previous" / "Next →".
- `src/components/RelatedPosts.astro`: "Related Posts" heading.
- `src/layouts/BlogPostLayout.astro`: "N min read" phrasing.
- `src/components/BlogFilter.astro`: empty-state `No posts match your filters. Show all posts`; pagination `Previous` / `Next`.
- 404 `<h1>Page not found</h1>` and `&larr; Back to home` link.
- 404 title `Page not found — How Do I AI` (em-dash is standard typographic title separator, not tagline pattern).

## Meta description character counts

All ≤ 160 chars per AC:

| Surface | Chars |
|---|---|
| Home | 110 |
| Blog index | 118 |
| 404 | 72 |
| RSS feed description | 98 |

## Voice gate

Every new string passes the gate (candid, concrete, POV, no corporate-speak):

- `AI first – for everything you do.` — tagline, POV.
- `… Practitioner walkthroughs, tool assessments, and the parts that didn't work.` — candid admission (matches about.astro voice).
- `That page isn't on How Do I AI — it may have moved, or it never existed.` — direct, no apology.
- `This page isn't here. It may have moved, or it never existed.` — direct body copy.
- `Every post from How Do I AI — practitioner walkthroughs on applying AI to real work. Filter by pillar, series, or tag.` — POV, concrete.

Scanned for corporate-speak (`leverage`, `synergize`, `empower`, `seamless`, `unlock`, `journey`, `optimize`, `solution`) — zero matches in user-visible updated copy.

## Note on `llms.txt`

Not in the explicit scope bullets of #75 but included on the same brand-drift reasoning: the line-3 tagline blockquote carried the same old tagline (`AI first. For all of it.`) as the footer / RSS / home meta, and the issue's title reads "Site-wide copy audit". Fixing the remaining three while leaving this one would have defeated the consistency goal. Flagged here so the reviewer can ask to split if they disagree.

## Out of scope (per issue)

- Homepage hero tagline + descriptor (#73 / #79 — already shipped).
- About page copy (closed #62).
- Actual blog post bodies (per-post author's concern).
- Footer channel-link labels (closed #60).
- JSON-LD copy fields (closed #63).

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings, 2 pre-existing hints (`eslint.config.js` tseslint deprecation, `BlogFilter.astro:371` unused `visibleCount` param — both unrelated to this PR).
- [x] `npm run test` — 38/38 pass.
- [x] `npm run build` — 5 pages built, no errors (includes `/rss.xml` and `sitemap-index.xml`).
- [x] `npm run lint` — clean.
- [x] `npx prettier --check .` — clean.
- [x] Verified `e2 80 93` (U+2013 en-dash) present in all 5 tagline-bearing surfaces (`dist/index.html` hero + meta, `dist/rss.xml`, footer block in built HTML, `public/llms.txt`). Verified via `xxd`.
- [x] `grep -rn 'AI first\. For all of it\.' .` returns 0 matches in `src/` and `public/` — old tagline fully retired.
- [x] Rendered meta tags inspected in `dist/index.html`, `dist/404.html`, `dist/blog/index.html`, `dist/rss.xml` — all carry the new strings.
- [x] Adversarial validation via fresh-context subclaude → VERDICT: **CLEAN** (all 4 testable ACs PASS; AC5 advisory RSS-validator check is post-deploy only).
- [x] Constructive polish via fresh-context subclaude → VERDICT: **CLEAN ENOUGH** (two non-blocking observations both deemed deliberate context adaptation — see the commit body for details).
- [ ] Post-deploy: feed the live `/rss.xml` to https://validator.w3.org/feed/ per AC5.
- [ ] Reviewer: eyes-on-pixels sanity check in browser (light + dark) — the copy is text-only but it's worth confirming that the new footer / 404 / blog-subtitle lengths still wrap reasonably.

Closes #75