### PR TITLE
(chore) remove Plausible Analytics wiring per PDR-005

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -56,15 +56,13 @@ const organizationSchema = Astro.site
     'unsafe-inline' on script-src covers the theme-flash script below.
     'unsafe-inline' on style-src covers Astro's scoped component styles,
     which are emitted as inline <style> blocks per component.
-    https://plausible.io on script-src and connect-src covers the
-    Plausible Analytics script and its event endpoint.
     A future hardening step is to generate build-time hashes for the
     inline script and replace script-src 'unsafe-inline' with a hash
     allowlist.
   -->
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://plausible.io; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+    content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
   />
 
   <!-- Open Graph -->
@@ -114,13 +112,6 @@ const organizationSchema = Astro.site
       }
     })();
   </script>
-
-  <!-- Plausible Analytics: cookieless, privacy-friendly page-view tracking -->
-  <script
-    is:inline
-    defer
-    data-domain="how-do-i.ai"
-    src="https://plausible.io/js/script.js"></script>
 
   {
     /*


### PR DESCRIPTION
## Summary

- Removes the Plausible Analytics wiring that landed via #61 / PR #67 / commit `a4e9bc7` — dead code (no Plausible account ever existed; script POSTed to an unregistered domain).
- Per **PDR-005** (analytics deferral at launch), no web analytics ships at launch.
- Self-contained single-file change: `src/components/BaseHead.astro`. CSP is now back to same-origin-only.

## Changes

`src/components/BaseHead.astro`:

- Remove the Plausible `<script>` block (`is:inline defer data-domain="how-do-i.ai" src="https://plausible.io/js/script.js"`).
- Remove the two Plausible rationale lines from the CSP comment block.
- Remove `https://plausible.io` from `script-src` and `connect-src` in the CSP meta tag.

Diff: 1 insertion (CSP meta `content=` replacement), 10 deletions.

## Verification

- [x] `rg -i plausible` across the repo → 0 matches.
- [x] `npm run build` → 5 pages built, complete.
- [x] `npm run typecheck` → 0 errors, 0 warnings (2 pre-existing hints, unrelated).
- [x] `npm run test` → 38/38 passed.
- [x] `npm run lint` + `npm run format:check` → clean.
- [x] `dist/index.html` CSP verified: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';`
- Validated via fresh-context subclaude → **VERDICT: CLEAN** (session `c8a33c83`).
- Polished via fresh-context subclaude → **VERDICT: CLEAN** (session `80042c27`).

## Out of scope

Per #81 and PDR-005:

- Any replacement analytics platform (deferred).
- Any CNIL self-assessment / opt-out mechanism (moot when no analytics ships).
- Reopening #61 (its original ACs are superseded by PDR-005).

## References

- Issue: #81
- Supersedes: #61, PR #67, commit `a4e9bc7`
- Decision: `hq/docs/decisions/PDR-005-analytics-deferral.md` (HQ repo, private — see [CONTRIBUTING.md § Cross-repo setup](./CONTRIBUTING.md#cross-repo-setup))
- Parking lot: `hq/docs/ideas-evaluated.md` § "Analytics at Launch (PDR-005)"

Closes #81