### PR TITLE
(chore) fix .gitignore screenshot comment PR/Issue reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist/
 
 # Temporary scratch files
 .tmp/*
-# Scoped exception: the PDR-006 branch-build PR (#98) requires visual-compare
+# Scoped exception: the PDR-006 branch-build work requires visual-compare
 # screenshots as a committed deliverable so GitHub renders them inline.
 !.tmp/branch-build-screenshots/
 


### PR DESCRIPTION
## Summary

Fixes cosmetic comment drift in `.gitignore:11-12`: the comment said "the PDR-006 branch-build PR (#98)" but #98 was the Issue and #99 was the PR that shipped the work. Rewrites to reference the PDR-006 branch-build work without tying to a specific issue/PR number — future-proofs against subsequent references and reads cleaner.

Functional rule unchanged: `.tmp/*` still ignored except `.tmp/branch-build-screenshots/`.

Closes #100

## Test plan

- [x] `npm run build` passes locally
- [x] Diff is a single-line comment text change (no behavioral impact)
- [ ] CI green