### PR TITLE
(chore) pillar label: Meta → Behind the Scenes (N2 fix)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,4 +16,4 @@ How Do I AI? is a publication, not a personal brand. Multi-format content — bl
 - [AI-First Thinking](https://how-do-i.ai/blog/?pillar=thinking): Mental models, the Default Question, editorial position — starting with "how would I do this if AI could do anything?" instead of "can AI help?".
 - [AI in Practice](https://how-do-i.ai/blog/?pillar=practice): Practitioner walkthroughs — real workflows applied to real work, including the parts that didn't work.
 - [Tools & Workflows](https://how-do-i.ai/blog/?pillar=tools): Tool assessments, integrations, and repeatable workflows. Honest takes — not neutral.
-- [Meta](https://how-do-i.ai/blog/?pillar=meta): About the publication itself — how it's made, editorial standards, the AI-first production process.
+- [Behind the Scenes](https://how-do-i.ai/blog/?pillar=meta): About the publication itself — how it's made, editorial standards, the AI-first production process.

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -10,7 +10,7 @@ export const PILLARS = {
   thinking: 'AI-First Thinking',
   practice: 'AI in Practice',
   tools: 'Tools & Workflows',
-  meta: 'Meta',
+  meta: 'Behind the Scenes',
 } as const;
 
 export const SERIES = {


### PR DESCRIPTION
## Summary

Aligns the 4th content pillar label in `src/lib/taxonomy.ts:13` with the authoritative spec (`hq/docs/website/prd.md` § 3 Enum Values, `hq/brand/messaging.md` § 6 Content Pillar Naming Convention) — surfaced during PR #99 pass-1 fresh-context review as Note N2.

- `src/lib/taxonomy.ts:13` — `meta: 'Meta'` → `meta: 'Behind the Scenes'` (primary, per AC1)
- `public/llms.txt:19` — `[Meta](...)` → `[Behind the Scenes](...)` (downstream label anchor text; required by AC6 "No downstream references to the literal string 'Meta' as a label" and PDR-006's cross-surface consistency rule)

Slug `meta` preserved everywhere; `?pillar=meta` URLs keep working (AC2). The Nav's existing `showMeta` conditional at `Nav.astro:12-19` continues to gate visibility until the first "Behind the Scenes" post publishes — no runtime change until then (AC3).

Scope is intentionally tight: this PR does **not** touch the broader slug drift (spec enum table at `prd.md:79-83` uses long slugs like `ai-first-thinking` while the code uses short slugs like `thinking`). Per ticket AC7, that is a separate decision for HQ spec resolution and will be raised as a follow-up.

## AC evidence

| AC | Status | Evidence |
|----|--------|----------|
| 1. Change `taxonomy.ts:13` label | ✅ | `src/lib/taxonomy.ts:13` diff shows `-'Meta'` → `+'Behind the Scenes'` |
| 2. Slug `meta` stays unchanged | ✅ | Property key `meta:` in taxonomy.ts unchanged; `?pillar=meta` in llms.txt URL unchanged |
| 3. Nav renders new label when activated | ✅ | `Nav.astro:43` renders `{pillar.label}` which now resolves to 'Behind the Scenes' through imported `PILLARS`; built `dist/blog/index.html` inlines `meta:"Behind the Scenes"` in the filter JS. Runtime path not visually testable yet (no published BTS post); will activate automatically on first such post. |
| 4. `npm run typecheck` passes | ✅ | 0 errors, 0 warnings (2 pre-existing hints in unrelated files) |
| 5. `npm run build` passes | ✅ | 5 pages built in 971ms, no errors |
| 6. No downstream `'Meta'` label references | ✅ | `grep -rn "'Meta'\|\"Meta\"\|\[Meta\]\|>Meta<"` excluding node_modules/dist/.tmp → no matches |
| 7. Flag broader slug drift to HQ | ⏳ | Follow-up HQ issue will be filed after this PR lands (keeps the batch atomic) |

Extra local CI parity: `npm audit --omit=dev` → 0 vulnerabilities; `npm run lint` → clean; `npm test` → 38/38 passing.

## Test plan

- [x] `npm run typecheck` locally — 0 errors
- [x] `npm test` locally — 38/38 passing
- [x] `npm run build` locally — 5 pages built, `dist/blog/index.html` contains `"Behind the Scenes"`, `dist/llms.txt` contains `[Behind the Scenes]`
- [x] `npm audit --omit=dev` locally — 0 vulnerabilities
- [x] `npm run lint` locally — clean
- [x] Repo-wide grep for `'Meta'`, `"Meta"`, `[Meta]`, `>Meta<` as label → no matches outside vendor/build artifacts
- [ ] CI (audit + lint + typecheck + test + build) — pending on this PR

## Refs

- Issue: #102
- Review source: PR #99 pass-1 fresh-context review (Note N2)
- Authoritative spec: `hq/docs/website/prd.md` § 3 Enum Values (line 83), `hq/brand/messaging.md` § 6 Content Pillar Naming Convention, `hq/docs/decisions/PDR-006-mobile-navigation-pattern.md`

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)