### PR TITLE
Blog Index: mobile responsive polish (per PDR-006)

### DIFF
--- a/src/components/BlogFilter.astro
+++ b/src/components/BlogFilter.astro
@@ -61,9 +61,18 @@
     width: 100%;
   }
 
+  /*
+    Active filter chips — mobile-first stacking. Base (<640px) stacks each
+    chip full-width with the × glyph pushed right via space-between; at
+    640px+ chips flow inline per ux-architecture.md § Mobile § Blog Index
+    (Pattern A posture: nothing hidden, touch-target ≥44px per REQ-MOB-03).
+    The 640px threshold is blog-index-specific (canonical tokens are 480/
+    768/1024; the 640-band is a page-local boundary from the spec).
+  */
   .filter-chips {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: stretch;
     gap: var(--space-2);
     margin-bottom: var(--space-6);
   }
@@ -74,11 +83,12 @@
   }
 
   .filter-chip {
-    display: inline-flex;
+    display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
-    min-height: 44px;
+    min-height: var(--touch-target);
     font-size: var(--text-sm);
     font-weight: 500;
     color: var(--color-text);
@@ -92,6 +102,19 @@
   .filter-chip:hover {
     background-color: var(--color-muted);
     color: var(--color-bg);
+  }
+
+  @media (min-width: 640px) {
+    .filter-chips {
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .filter-chip {
+      display: inline-flex;
+      justify-content: flex-start;
+    }
   }
 
   .filter-chip-x {
@@ -129,10 +152,18 @@
     }
   }
 
+  /*
+    Pagination — mobile-first full-width row. Base (<640px) uses
+    space-between so Previous anchors to the left, Next to the right, and
+    the pages container sits between (wrapping if the full "< Previous
+    1 2 3 ... N Next >" pattern won't fit on one line at narrow widths).
+    At 640px+ pagination returns to centered per the pre-PDR-006 layout
+    (spec: "Pagination inline" at 640-767px, unchanged at 768px+).
+  */
   .pagination {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: space-between;
     gap: var(--space-2);
     margin-top: var(--space-8);
     flex-wrap: wrap;
@@ -146,10 +177,16 @@
     display: none;
   }
 
+  @media (min-width: 640px) {
+    .pagination {
+      justify-content: center;
+    }
+  }
+
   .pagination-btn {
     padding: var(--space-2) var(--space-4);
-    min-height: 44px;
-    min-width: 44px;
+    min-height: var(--touch-target);
+    min-width: var(--touch-target);
     font-size: var(--text-sm);
     font-weight: 500;
     color: var(--color-text);
@@ -174,7 +211,9 @@
 
   .pagination-pages {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
     gap: var(--space-1);
   }
 
@@ -182,8 +221,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 44px;
-    min-height: 44px;
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
     padding: 0 var(--space-2);
     font-size: var(--text-sm);
     font-weight: 500;


### PR DESCRIPTION
Closes #91.

## Summary

Applies PDR-006 mobile spec to the blog index via CSS polish on `src/components/BlogFilter.astro`. Scope: active filter chips + pagination at `<640px`; `640-767px` and `768px+` layouts unchanged.

## Changes

**`src/components/BlogFilter.astro`** (CSS-only):

- `.filter-chips` base: `flex-direction: column; align-items: stretch` — active filter chips stack full-width at `<640px`.
- `.filter-chip` base: `display: flex; justify-content: space-between` — `×` glyph anchored right on full-width chips.
- `.pagination` base: `justify-content: space-between` — Previous anchors left, Next anchors right; pages wrap between.
- `.pagination-pages`: added `flex-wrap: wrap; justify-content: center` so page buttons wrap cleanly at narrow viewports (320 px × 7 page buttons × 44 px can't fit inline).
- `@media (min-width: 640px)` blocks revert each rule to the pre-polish inline / centered layout, so 640–767 px and 768 px+ are unaffected.
- Magic `44px` → `var(--touch-target)` on `.filter-chip`, `.pagination-btn`, `.pagination-page` per REQ-MOB-04 token baseline — consistent with Nav.astro / PostCard.

**`src/pages/blog/index.astro`**: unchanged (existing `var(--space-6)` horizontal padding provides adequate 320 px gutter; out of scope per caller guidance).

## Scope note

The issue AC text references pillar / series / tag filter chip UI (stacked row, collapsible `<details>`). That UI does not currently exist in `BlogFilter.astro` — the implementation is URL-parameter-based with only the active-filter chips rendered (from `#filter-chips` populated by JS on apply). Adding pillar / series / tag selector rows is a feature-scope change beyond "mobile polish" and is not addressed here.

## Acceptance criteria coverage

- [x] `<640px`: active filter chips full-width stacked; pagination full-width row with `< Previous 1 2 3 ... N Next >` pattern preserved via space-between + wrap.
- [x] `640-767px`: filter chips + pagination inline (centered).
- [x] `768px+`: unchanged.
- [x] All interactive elements use `var(--touch-target)` (44 px).
- [x] `aria-live="polite"` filter state announcement untouched (REQ-A11Y-04).
- [ ] Verify at 320 / 360 / 375 / 414 / 480 / 640 / 768 viewports — Playwright visual regression (QA-09) runs pre-merge; branch-build-screenshots baseline is in `.tmp/branch-build-screenshots/`.

## Test plan

- `npm run lint` — 0 errors / 0 warnings
- `npm run typecheck` — clean
- `npm run test` — 38 / 38 pass
- `npm run build` — 5 pages built
- Visual regression: reviewer to compare blog-index screenshots at the canonical mobile width set against the PDR-006 branch-build baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)