### PR TITLE
(chore) footer: mobile stacked full-width + copyright per PDR-006

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -49,6 +49,8 @@ const channels: Channel[] = [
     path: 'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z',
   },
 ];
+
+const currentYear = new Date().getFullYear();
 ---
 
 <footer class="site-footer">
@@ -107,6 +109,7 @@ const channels: Channel[] = [
         </li>
       </ul>
     </nav>
+    <p class="copyright">© {currentYear} How Do I AI?</p>
   </div>
 </footer>
 
@@ -127,7 +130,8 @@ const channels: Channel[] = [
     gap: var(--space-4);
   }
 
-  .tagline {
+  .tagline,
+  .copyright {
     font-size: var(--text-sm);
     color: var(--color-muted);
     margin: 0;
@@ -186,11 +190,16 @@ const channels: Channel[] = [
     flex-shrink: 0;
   }
 
-  /* Mobile: stack tagline above channel list, wrap links to multiple rows. */
+  /* Mobile: stacked full-width sections at <640px per PDR-006 § Per-page / ux-architecture § Mobile § Footer. */
   @media (max-width: 639px) {
     .footer-inner {
       flex-direction: column;
-      align-items: flex-start;
+      align-items: stretch;
+    }
+
+    .footer-link,
+    .channel-link {
+      min-width: var(--touch-target);
     }
   }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -50,7 +50,9 @@ const channels: Channel[] = [
   },
 ];
 
-const currentYear = new Date().getFullYear();
+// In static output this value is baked in at build time and updates on rebuild.
+// UTC avoids off-by-one around New Year depending on build-machine timezone.
+const currentYear = new Date().getUTCFullYear();
 ---
 
 <footer class="site-footer">
@@ -135,6 +137,12 @@ const currentYear = new Date().getFullYear();
     font-size: var(--text-sm);
     color: var(--color-muted);
     margin: 0;
+  }
+
+  /* Copyright always takes its own row so it never perturbs the
+     justify-content: space-between distribution of other sections. */
+  .copyright {
+    flex-basis: 100%;
   }
 
   .footer-primary {


### PR DESCRIPTION
## Summary

Applies PDR-006 per-page mobile responsive spec to `src/components/Footer.astro` — the smallest of the per-page polishes. Stacked full-width sections at <640px; existing inline horizontal layout at 640px+ is unchanged.

Closes #93.

**Batch context**: track-6 of `/do-all` batch `20260420-8f70`. Orchestrator merges; this PR stops at CI green.

## Changes

Single file, +12 / −3:

1. **DOM**: Added `<p class=\"copyright\">© {currentYear} How Do I AI?</p>` after the channels nav. Year is dynamic (`new Date().getFullYear()` at build).
2. **CSS `@media (max-width: 639px)`**:
   - Changed `align-items: flex-start` → `align-items: stretch` so sections span the flex-column container's full width.
   - Added `min-width: var(--touch-target)` to `.footer-link, .channel-link` for WCAG 2.5.5 touch-target *width* (min-height of 44px was already in place).
3. **CSS shared selector**: `.tagline, .copyright` combined for muted-text styling (no duplication).
4. **Comment**: Mobile media-query header references PDR-006 and ux-architecture.md.

## AC (per #93)

| # | AC | Status | Evidence |
|---|---|---|---|
| 1 | At <640px: stacked full-width sections (RSS, tagline, copyright) | ✅ | `align-items: stretch` stretches each child nav/p to full container width. Screenshots 320/360/375/414/480 confirm. |
| 2 | At 640px+: inline horizontal layout (current) | ✅ | No CSS change to ≥640px rules. Screenshots 640/768 confirm no regression. |
| 3 | Interactive elements ≥44×44px on mobile | ✅ | Pre-existing `min-height: 44px` + added `min-width: var(--touch-target)` at <640px. |
| 4 | RSS link in footer repeats (nav + footer) for WCAG 2.4.5 \"Multiple Ways\" | ✅ | `Nav.astro:53` and `Footer.astro:90` both reference `/rss.xml`. |
| 5 | Verify at 320/360/375/414/480/640/768 viewports | ✅ | 14 screenshots captured via Playwright (7 widths × light+dark). All render as expected. |

## Local CI (all green)

```
npm run lint           → clean
npm run format:check   → clean
npm run typecheck      → 0 errors, 0 warnings, 2 pre-existing hints (unrelated)
npm run test           → 38/38 passed
npm run build          → 5 pages, 956ms, complete
```

## Scope interpretation (flagging for reviewer)

PDR-006 § Per-page table row says: *\"Stacked full-width at <640px; **RSS + tagline + copyright only**\"* — the emphasised \"only\" could be read to mean the About link and 8 social channels should be removed entirely.

This PR takes a **conservative, autonomous-safe interpretation**:

- Applies the **structural** changes (stacking, full-width, copyright) per spec.
- **Preserves** the existing About link and social channels, because:
  - The issue #93 AC does not mention content removal.
  - The issue title/description frames this as \"polish\" / \"smallest of the per-page polishes.\"
  - Caller scope: `src/components/Footer.astro only. Stacked full-width at <640px, inline 640px+. RSS link repeats...` — structural, not editorial.
  - Content removal has SEO/brand implications not appropriate for autonomous execution.

If the PDR-006 author intended strict removal of About + socials, that's a separate, reviewable editorial decision; a follow-up issue can handle it and this structural polish remains independently valuable.

## Test plan

- [ ] Open `/` on mobile (<640px): tagline, About, channels (wrapping), copyright stack full-width
- [ ] Open `/` on 640px+: tagline + About inline at top; channels below; copyright at bottom
- [ ] Tap-test a channel link on mobile — target is at least 44×44
- [ ] RSS link still present in footer (and nav)
- [ ] Copyright shows current year
- [ ] Dark mode: muted text reads correctly (verified at 375px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)