### PR TITLE
(feat) blog post mobile polish per PDR-006 (#92)

### DIFF
--- a/src/components/PrevNextNav.astro
+++ b/src/components/PrevNextNav.astro
@@ -52,16 +52,16 @@ const showNav = prevPost || nextPost;
 
 <style>
   .prev-next-nav {
-    max-width: 680px;
+    max-width: var(--reading-max);
     margin-inline: auto;
-    padding-inline: var(--space-6);
+    padding-inline: var(--space-section-x);
     padding-block: var(--space-8);
     border-top: 1px solid var(--color-surface);
   }
 
   .prev-next-inner {
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
     gap: var(--space-6);
   }
 
@@ -70,7 +70,7 @@ const showNav = prevPost || nextPost;
     flex-direction: column;
     gap: var(--space-1);
     text-decoration: none;
-    max-width: 50%;
+    max-width: 100%;
     min-height: 44px;
     padding: var(--space-2) 0;
     transition: color var(--transition-fast);
@@ -85,8 +85,7 @@ const showNav = prevPost || nextPost;
   }
 
   .nav-next {
-    text-align: right;
-    margin-left: auto;
+    text-align: left;
   }
 
   .nav-label {
@@ -100,5 +99,22 @@ const showNav = prevPost || nextPost;
     color: var(--color-text);
     line-height: var(--leading-tight);
     transition: color var(--transition-fast);
+  }
+
+  /* Side-by-side layout above base band — prev-left / next-right */
+  @media (min-width: 480px) /* --bp-sm */ {
+    .prev-next-inner {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    .nav-link {
+      max-width: 50%;
+    }
+
+    .nav-next {
+      text-align: right;
+      margin-left: auto;
+    }
   }
 </style>

--- a/src/components/PullQuote.astro
+++ b/src/components/PullQuote.astro
@@ -14,7 +14,7 @@
 <style>
   .pull-quote {
     font-family: var(--font-sans);
-    font-size: var(--text-xl);
+    font-size: var(--text-lg);
     font-weight: 600;
     line-height: var(--leading-normal);
     color: var(--color-text);
@@ -23,5 +23,13 @@
     padding: var(--space-6);
     margin-block: var(--space-8);
     border-radius: var(--radius-md);
+  }
+
+  /* Step up to desktop emphasis above the base band; weight + border + surface
+     preserve hierarchy on mobile at the body-size step. */
+  @media (min-width: 480px) /* --bp-sm */ {
+    .pull-quote {
+      font-size: var(--text-xl);
+    }
   }
 </style>

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -52,9 +52,9 @@ const { posts } = Astro.props;
   }
 
   .related-posts-inner {
-    max-width: 680px;
+    max-width: var(--reading-max);
     margin-inline: auto;
-    padding-inline: var(--space-6);
+    padding-inline: var(--space-section-x);
   }
 
   .related-heading {
@@ -66,5 +66,12 @@ const { posts } = Astro.props;
   .related-grid {
     display: grid;
     gap: var(--space-2);
+  }
+
+  /* 2-column layout above the base band */
+  @media (min-width: 480px) /* --bp-sm */ {
+    .related-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
 </style>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -6,8 +6,8 @@
  * Mobile: collapsible details/summary, collapsed by default.
  * Desktop: always expanded.
  *
- * Renders with the `open` attribute so content is visible without JS.
- * A small inline script closes the disclosure on narrow viewports.
+ * Renders without the `open` attribute so mobile (no-JS and JS) starts
+ * collapsed. A tiny inline script opens the disclosure on ≥768px.
  *
  * Props:
  *   headings — array of { depth, slug, text } from Astro's getHeadings()
@@ -26,7 +26,7 @@ const shouldRender = h2Headings.length >= 4;
 {
   shouldRender && (
     <nav class="toc" aria-label="Table of contents">
-      <details class="toc-details" open>
+      <details class="toc-details">
         <summary class="toc-summary">Table of contents</summary>
         <ol class="toc-list">
           {h2Headings.map((h) => (
@@ -40,13 +40,16 @@ const shouldRender = h2Headings.length >= 4;
   )
 }
 
-<script>
-  // Collapse TOC on mobile; leave expanded on desktop.
+<script is:inline>
+  // Open TOC by default on desktop; mobile stays collapsed.
+  // Inline + synchronous so it runs before paint and avoids a desktop flash.
   // No-ops on pages without a .toc-details element.
-  const details = document.querySelector('.toc-details');
-  if (details && window.matchMedia('(max-width: 767px)').matches) {
-    details.removeAttribute('open');
-  }
+  (function () {
+    const d = document.querySelector('.toc-details');
+    if (d && window.matchMedia('(min-width: 768px)').matches) {
+      d.setAttribute('open', '');
+    }
+  })();
 </script>
 
 <style>
@@ -112,13 +115,11 @@ const shouldRender = h2Headings.length >= 4;
     color: var(--color-accent);
   }
 
-  /* Desktop: hide disclosure toggle, keep always expanded */
-  @media (min-width: 768px) {
-    .toc-summary {
-      pointer-events: none;
-      cursor: default;
-    }
-
+  /* Desktop: hide the disclosure chevron. The summary stays interactive so
+     (1) a JS-off visitor can still open the TOC manually, and (2) a visitor
+     who prefers a collapsed TOC can toggle it closed. JS opens the details
+     by default on first paint; user interaction takes over from there. */
+  @media (min-width: 768px) /* --bp-md */ {
     .toc-summary::before {
       display: none;
     }

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -129,9 +129,9 @@ const breadcrumbSchema = Astro.site
      ------------------------------------------------------------------ */
 
   .post {
-    max-width: 680px;
+    max-width: var(--reading-max);
     margin-inline: auto;
-    padding-inline: var(--space-6);
+    padding-inline: var(--space-section-x);
     padding-block: var(--space-12) var(--space-16);
   }
 


### PR DESCRIPTION
## Summary

Apply PDR-006 mobile spec to blog post rendering. Closes #92.

- **Reading column** uses `var(--space-section-x)` for 16px base gutter; max-width switched to `var(--reading-max)` token (same 680px).
- **Body type stays static 18px** (`var(--text-lg)`) — preserves 45-75ch measure anchor per PDR-006. No fluid clamp applied to `.prose`.
- **TOC**: details now renders WITHOUT `open` by default; a pre-paint `<script is:inline>` sets `open` at `matchMedia('(min-width: 768px)').matches`. Removes the prior mobile expand-flash (post-DOMContentLoaded removeAttribute). Desktop `@media (min-width: 768px)` now only hides the chevron — summary remains interactive so JS-off visitors can still toggle and users who prefer the list collapsed can toggle closed.
- **Prev/next nav**: stacks full-width at base (`flex-direction: column`, `max-width: 100%`), flips to side-by-side at `@media (min-width: 480px)` (prev-left, next-right). Padding switched to `var(--space-section-x)` + max-width to `var(--reading-max)` for reading-column visual alignment.
- **Related posts**: 2-column grid activates at `@media (min-width: 480px)`. Single-column at base remains the implicit `display: grid` default. Padding switched to `var(--space-section-x)` + max-width to `var(--reading-max)` for reading-column alignment. (Desktop 768+ now matches ux-architecture.md:181 spec; previously 1-column — AC "At 768px+: unchanged" interpreted as "unchanged from SPEC", not "preserve prior bug".)
- **Pull quote**: steps down to 18px (`var(--text-lg)`) at base; steps to 20px (`var(--text-xl)`) at `@media (min-width: 480px)`. 4px Signal Orange left border + semibold weight + surface background retained for hierarchy.

Also adds the `/* --bp-md */` token-reference comment to the existing 768px `@media` rule in `TableOfContents.astro` (REQ-MOB-02 compliance while touching the file). Other pre-existing `@media` drift in `BlogFilter.astro` left untouched (out of scope).

Code-block horizontal scroll, anchor `scroll-padding-top`, and 44×44 touch targets on discrete interactive elements (TOC summary/items, prev/next cards) are satisfied by existing styles — no changes. Inline prose links covered by WCAG 2.5.8 inline-link exemption.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — 0 errors (2 pre-existing warnings in BlogFilter.astro/eslint config)
- [x] `npm run test` — 38/38 pass
- [x] `npm run build` — 5 pages, clean
- [x] Visual check at 320 / 360 / 375 / 479 / 480 / 640 / 767 / 768 / 1024 via Playwright screenshots (in `.tmp/92-screenshots/` and `.tmp/92-screenshots-bottom/`)
  - 320: badges fit above H1, 16px gutter, TOC collapsed
  - 479: prev/next stacked, related 1-col
  - 480: prev/next side-by-side, related 2-col, pull quote steps to 20px
  - 768: TOC opens via JS with chevron hidden; summary remains interactive
- [x] Temp fixtures (3 test posts + 1 pullquote test page) created for visual verification and deleted before commit — not in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)