### PR TITLE
(chore) migrate hardcoded literals to tokens per #101

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -123,7 +123,7 @@ const currentYear = new Date().getUTCFullYear();
   }
 
   .footer-inner {
-    max-width: 64rem;
+    max-width: var(--content-max);
     margin: 0 auto;
     display: flex;
     flex-wrap: wrap;
@@ -154,7 +154,7 @@ const currentYear = new Date().getUTCFullYear();
   .footer-link {
     display: inline-flex;
     align-items: center;
-    min-height: 44px;
+    min-height: var(--touch-target);
     padding: var(--space-2) 0;
     font-size: var(--text-sm);
     color: var(--color-muted);
@@ -181,7 +181,7 @@ const currentYear = new Date().getUTCFullYear();
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
-    min-height: 44px;
+    min-height: var(--touch-target);
     padding: var(--space-2) 0;
     font-size: var(--text-sm);
     color: var(--color-muted);

--- a/src/components/PrevNextNav.astro
+++ b/src/components/PrevNextNav.astro
@@ -71,7 +71,7 @@ const showNav = prevPost || nextPost;
     gap: var(--space-1);
     text-decoration: none;
     max-width: 100%;
-    min-height: 44px;
+    min-height: var(--touch-target);
     padding: var(--space-2) 0;
     transition: color var(--transition-fast);
   }

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -70,7 +70,7 @@ const shouldRender = h2Headings.length >= 4;
     cursor: pointer;
     list-style: none;
     user-select: none;
-    min-height: 44px;
+    min-height: var(--touch-target);
     display: flex;
     align-items: center;
   }
@@ -104,7 +104,7 @@ const shouldRender = h2Headings.length >= 4;
   .toc-item a {
     display: inline-flex;
     align-items: center;
-    min-height: 44px;
+    min-height: var(--touch-target);
     font-size: var(--text-sm);
     color: var(--color-text);
     text-decoration: none;

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -60,8 +60,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 44px;
-    min-height: 44px;
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
     padding: 0;
     border: none;
     border-radius: var(--radius-md);

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -46,7 +46,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .not-found-link {
     display: inline-flex;
     align-items: center;
-    min-height: 44px;
+    min-height: var(--touch-target);
     font-weight: 600;
     font-size: var(--text-base);
     color: var(--color-accent);

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -78,7 +78,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <style>
   .about {
-    max-width: 680px;
+    max-width: var(--reading-max);
     margin-inline: auto;
     padding-inline: var(--space-6);
     padding-block: var(--space-12) var(--space-16);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -36,7 +36,7 @@ const posts = await getPublishedPosts();
 
 <style>
   .blog-index {
-    max-width: 64rem;
+    max-width: var(--content-max);
     margin: 0 auto;
     padding: var(--space-8) var(--space-6);
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -137,7 +137,7 @@ const hasPosts = posts.length > 0;
 
   /* Recent posts section */
   .recent {
-    max-width: 64rem;
+    max-width: var(--content-max);
     margin-inline: auto;
     padding: var(--space-8) var(--space-4);
   }


### PR DESCRIPTION
## Summary

Closes #101.

Replace 13 hardcoded literal values across 8 consumer files with the canonical design tokens introduced in PR #99 (`--reading-max`, `--content-max`, `--touch-target`). Byte-identical substitution — no computed-value change, no visual change.

## Scope

| Literal | Token | Sites | Files |
|---|---|---|---|
| `max-width: 680px` | `var(--reading-max)` | 1 | `src/pages/about.astro` |
| `max-width: 64rem` | `var(--content-max)` | 3 | `src/components/Footer.astro`, `src/pages/index.astro`, `src/pages/blog/index.astro` |
| `min-height: 44px` | `var(--touch-target)` | 8 | `src/components/PrevNextNav.astro`, `src/components/Footer.astro` (×2), `src/components/ThemeToggle.astro`, `src/components/TableOfContents.astro` (×2), `src/pages/404.astro` |
| `min-width: 44px` | `var(--touch-target)` | 1 | `src/components/ThemeToggle.astro` |

Diffstat: `8 files changed, 12 insertions(+), 12 deletions(-)`.

Two AC items from #101 were already migrated by Wave 3 polish PRs (#105–#108) and grep-confirmed absent at this point:
- `clamp(var(--text-4xl), 8vw, 4rem)` → `var(--text-fluid-hero)` — already applied
- Section padding `var(--space-16) var(--space-4)` → `var(--space-section-y)/x` — already applied

## Why this is safe

Tokens in `src/styles/tokens.css` resolve to the exact literal values being replaced:

```css
--reading-max: 680px;
--content-max: 64rem;
--touch-target: 44px;
```

At CSS cascade time, `max-width: var(--reading-max)` resolves to `max-width: 680px` byte-for-byte. Same for `--content-max` / `64rem` and `--touch-target` / `44px`. No layout math changes.

## Test plan

- [x] `grep -rn "max-width: 680px\|max-width: 64rem\|min-height: 44px\|min-width: 44px" src/` → 0 matches.
- [x] `npm run typecheck` → 0 errors, 0 warnings (2 pre-existing hints unchanged).
- [x] `npm run build` → 5 pages built.
- [x] Visual regression (apples-to-apples, same commit base): 66/66 screenshots SHA-256 identical across widths 320/375/414/480/500/600/640/700/767/768/1024 × home/blog-index/blog-post × light/dark. Method: stash → rebuild pre-migration → screenshot → unstash → rebuild post-migration → screenshot → SHA-256 diff.
- [x] Fresh-context polish pass (`claude-subprocess`, session `dfa42ac4-bb6a`, $0.76): CLEAN, no findings.

## References

- Issue: #101
- Preceded by PR #99 (tokens added)
- Follows Wave 3 polish PRs (#105, #106, #107, #108) which opportunistically migrated hero and section-padding tokens