### PR TITLE
(chore) playwright touch-target audit suite per #95 (QA-07)

### DIFF
--- a/.github/workflows/touch-targets.yml
+++ b/.github/workflows/touch-targets.yml
@@ -1,0 +1,38 @@
+name: Touch-target audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run touch-target audit
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ dist/
 # Astro generated types
 .astro/
 
+# Playwright artifacts
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
 # Temporary scratch files
 .tmp/*
 # Scoped exception: the PDR-006 branch-build work requires visual-compare

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
+        "@playwright/test": "^1.59.1",
         "eslint": "^10.2.0",
         "eslint-plugin-astro": "^1.7.0",
         "prettier": "^3.8.3",
@@ -1525,6 +1526,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -5938,6 +5955,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "astro": "astro",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install --with-deps chromium",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
+    "@playwright/test": "^1.59.1",
     "eslint": "^10.2.0",
     "eslint-plugin-astro": "^1.7.0",
     "prettier": "^3.8.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig } from '@playwright/test';
+
+// Per QA-07 + PDR-006 Measurement Baseline:
+// mandatory viewports for mobile touch-target audit.
+const VIEWPORTS = [
+  { name: 'mobile-320', width: 320, height: 568 },
+  { name: 'mobile-375', width: 375, height: 667 },
+  { name: 'mobile-414', width: 414, height: 736 },
+  { name: 'mobile-768', width: 768, height: 1024 },
+] as const;
+
+const CI = !!process.env.CI;
+const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:4321';
+
+export default defineConfig({
+  testDir: 'tests',
+  fullyParallel: true,
+  forbidOnly: CI,
+  retries: CI ? 1 : 0,
+  workers: CI ? 2 : undefined,
+  reporter: CI
+    ? [['github'], ['html', { open: 'never' }], ['list']]
+    : 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+  },
+  projects: VIEWPORTS.map((v) => ({
+    name: v.name,
+    use: {
+      browserName: 'chromium',
+      viewport: { width: v.width, height: v.height },
+      hasTouch: true,
+    },
+  })),
+  webServer: {
+    command: 'npm run build && npm run preview -- --host 127.0.0.1 --port 4321',
+    url: BASE_URL,
+    timeout: 180_000,
+    reuseExistingServer: !CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/tests/a11y/touch-targets.spec.ts
+++ b/tests/a11y/touch-targets.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+
+// REQ-A11Y-05 + REQ-MOB-03 + QA-07:
+// Every interactive element at <768px viewports must meet 44×44 hit area.
+// 768 is included as a belt-and-suspenders boundary check per QA-07 METER.
+const MIN_TARGET = 44;
+
+// Issue #95 AC: load /, /blog/, at least one /blog/[slug]/.
+const PAGES: ReadonlyArray<{ label: string; path: string }> = [
+  { label: 'home', path: '/' },
+  { label: 'blog-index', path: '/blog/' },
+  { label: 'blog-post', path: '/blog/sample-post/' },
+];
+
+// Issue #95 AC: <a>, <button>, <details summary>, <input>.
+const INTERACTIVE_SELECTOR = 'a, button, details > summary, input';
+
+type Violation = {
+  tag: string;
+  id: string;
+  className: string;
+  role: string | null;
+  text: string;
+  href: string | null;
+  width: number;
+  height: number;
+  lineHeight: number;
+  effectiveHeight: number;
+  display: string;
+  location: { x: number; y: number };
+};
+
+for (const { label, path } of PAGES) {
+  test(`touch targets: ${label} (${path})`, async ({ page }, testInfo) => {
+    await page.goto(path, { waitUntil: 'networkidle' });
+
+    const viewport = page.viewportSize();
+    expect(viewport, 'viewport must be set').not.toBeNull();
+
+    const violations: Violation[] = await page.evaluate(
+      ({ selector, MIN }) => {
+        function round(n: number): number {
+          return Math.round(n * 100) / 100;
+        }
+
+        const results: Violation[] = [];
+        const elements = Array.from(
+          document.querySelectorAll<HTMLElement>(selector),
+        );
+
+        for (const el of elements) {
+          const style = window.getComputedStyle(el);
+
+          // Hidden via CSS — not part of the interactive surface.
+          if (
+            style.display === 'none' ||
+            style.visibility === 'hidden' ||
+            parseFloat(style.opacity) === 0
+          ) {
+            continue;
+          }
+
+          // hidden attribute or type=hidden input.
+          if (el.hasAttribute('hidden')) continue;
+          if (el instanceof HTMLInputElement && el.type === 'hidden') continue;
+
+          const rect = el.getBoundingClientRect();
+
+          // Zero-dimension elements are typically sr-only / visually-hidden
+          // (e.g. skip links). They are a11y-compliant as-is and expand to
+          // full size on focus; exclude from the layout-based audit.
+          if (rect.width === 0 || rect.height === 0) continue;
+
+          // Off-screen elements positioned outside the viewport are also
+          // typically sr-only patterns (left: -9999px). Skip.
+          if (
+            rect.right <= 0 ||
+            rect.bottom <= 0 ||
+            rect.left >= window.innerWidth
+          ) {
+            continue;
+          }
+
+          // For inline elements, the hit area extends with line-height
+          // (REQ-MOB-03: "either the link itself is ≥44px line-height or
+          // surrounding padding/margin produces a ≥44×44px effective hit area").
+          const lineHeightRaw = parseFloat(style.lineHeight);
+          const lineHeight = Number.isFinite(lineHeightRaw)
+            ? lineHeightRaw
+            : rect.height;
+          const isInline = style.display === 'inline';
+          const effectiveHeight = isInline
+            ? Math.max(rect.height, lineHeight)
+            : rect.height;
+
+          if (rect.width < MIN || effectiveHeight < MIN) {
+            const anchor = el instanceof HTMLAnchorElement ? el.href : null;
+            results.push({
+              tag: el.tagName.toLowerCase(),
+              id: el.id,
+              className:
+                typeof el.className === 'string' ? el.className : '',
+              role: el.getAttribute('role'),
+              text: (el.textContent ?? '').trim().slice(0, 80),
+              href: anchor,
+              width: round(rect.width),
+              height: round(rect.height),
+              lineHeight: round(lineHeight),
+              effectiveHeight: round(effectiveHeight),
+              display: style.display,
+              location: { x: round(rect.left), y: round(rect.top) },
+            });
+          }
+        }
+
+        return results;
+      },
+      { selector: INTERACTIVE_SELECTOR, MIN: MIN_TARGET },
+    );
+
+    // Attach JSON report for easier debugging when a violation is found.
+    if (violations.length > 0) {
+      await testInfo.attach('touch-target-violations.json', {
+        body: JSON.stringify(violations, null, 2),
+        contentType: 'application/json',
+      });
+    }
+
+    expect(
+      violations,
+      `Found ${violations.length} under-sized interactive element(s) at ` +
+        `${viewport?.width}×${viewport?.height} on ${path}. ` +
+        `Minimum hit area: ${MIN_TARGET}×${MIN_TARGET}px. ` +
+        `Details:\n${JSON.stringify(violations, null, 2)}`,
+    ).toEqual([]);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Vitest runs unit tests under src/.
+    // Playwright e2e tests live under tests/ and are run by `npm run test:e2e`.
+    exclude: [...configDefaults.exclude, 'tests/**', 'playwright-report/**'],
+  },
+});


### PR DESCRIPTION
## Summary

Implements **QA-07** (Playwright touch-target audit suite) per PRD § QA-07 and PDR-006 Measurement Baseline. Binary gate — test fails on any interactive element below 44×44px.

Closes #95.

### What shipped

| File | Purpose |
|------|---------|
| `tests/a11y/touch-targets.spec.ts` | Asserts every `<a>`, `<button>`, `<details summary>`, `<input>` renders with clickable area ≥44×44px on `/`, `/blog/`, `/blog/sample-post/` at viewports 320/375/414/768 (3 pages × 4 viewports = 12 deterministic test cases). |
| `playwright.config.ts` | Projects per viewport (chromium + hasTouch); `webServer` builds + serves via `npm run preview` on 127.0.0.1:4321. |
| `.github/workflows/touch-targets.yml` | PR gate — runs on push to main and on PR → main. Uploads Playwright HTML report on failure for triage. |
| `package.json` | `@playwright/test@^1.59.1` as devDep; `test:e2e` + `test:e2e:install` scripts. |
| `.gitignore` | Ignores `test-results/`, `playwright-report/`, `playwright/.cache/`. |

### Design notes

- **Binary fail**: any single under-sized element fails the test for that viewport×page pair. Violations are attached to the test report as structured JSON for triage.
- **Inline hit-area handling** (REQ-MOB-03): for `display: inline` elements, the effective height uses `max(rect.height, line-height)` — honors the "either ≥44px line-height or ≥44×44px effective hit area" clause. `inline-flex` / `inline-block` / block elements are measured by `getBoundingClientRect` directly.
- **Exclusions**: hidden via `display:none` / `visibility:hidden` / `opacity:0`; `[hidden]` attribute; `<input type=hidden>`; zero-dimension elements (typical sr-only pattern — skip link included); elements whose bounding rect falls entirely outside the viewport.
- **768 viewport**: included per QA-07 METER as a belt-and-suspenders check at the mobile→desktop breakpoint.
- **Local run**: `npm run test:e2e:install && npm run test:e2e`.

### Gate status on current `main`

The audit correctly identifies three REQ-MOB-03 violations already present in `main` (the gate is catching real issues, which is the intended behavior):

| Element | Viewports | Dimensions | Fix location |
|---------|-----------|------------|--------------|
| `<a class=\"wordmark\">How Do I AI?` | 320/375/414/768 | 160.33 × **32** | Nav: wordmark link needs `min-height: 44px` |
| `<a class=\"footer-link\">About` | 768 only | **39.48** × 44 | Footer: About link needs `min-width: 44px` |
| `<a class=\"channel-link\">X` (and other channel icons) | 768 only | **33.56** × 44 | Footer: channel-link icons need `min-width: 44px` |

These are not part of this PR's scope (issue #95 is explicitly the audit suite, not the fixes — per `Blocked by: implementation tickets ideally merged first`). Separate tickets should track the three fixes so this gate can go green.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:e2e` — 12 tests run, deterministically fail on current main due to real REQ-MOB-03 violations enumerated above
- [x] Playwright config's `webServer` builds and serves dist/ for the test run (CI and local)
- [ ] CI workflow runs on this PR (will fail by design; follow-up PRs fixing wordmark/footer dimensions will take it green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)