### PR TITLE
(chore) a11y: Playwright + axe-core WCAG 2.2 AA suite per #96

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,19 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: A11y — axe-core WCAG 2.2 AA
+        run: npm run test:a11y
+
+      - name: Upload a11y artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-axe-results
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,7 @@ web_modules/
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Playwright test artifacts
+test-results/
+playwright-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
+        "@axe-core/playwright": "^4.11.2",
+        "@playwright/test": "^1.59.1",
         "eslint": "^10.2.0",
         "eslint-plugin-astro": "^1.7.0",
         "prettier": "^3.8.3",
@@ -243,6 +245,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1525,6 +1540,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -2914,6 +2945,16 @@
       },
       "peerDependencies": {
         "@astrojs/compiler": ">=0.27.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
@@ -5938,6 +5979,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "astro": "astro",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:a11y": "playwright test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -22,6 +23,8 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
+    "@axe-core/playwright": "^4.11.2",
+    "@playwright/test": "^1.59.1",
     "eslint": "^10.2.0",
     "eslint-plugin-astro": "^1.7.0",
     "prettier": "^3.8.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright configuration for the accessibility gate.
+ *
+ * Serves the production build via `astro preview` and runs axe-core
+ * scans against it. See tests/a11y/axe.spec.ts for scope (viewports,
+ * pages, color modes) and QA-08 in docs/website/prd.md for requirements.
+ *
+ * webServer spins up its own preview process per run (rebuilds first so
+ * local `npm run test:a11y` is self-contained). In CI the existing
+ * `npm run build` step has already produced `dist/`, so the rebuild is a
+ * near-no-op incremental pass.
+ */
+export default defineConfig({
+  testDir: './tests/a11y',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm run build && npm run preview',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/tests/a11y/axe.spec.ts
+++ b/tests/a11y/axe.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * axe-core WCAG 2.2 AA accessibility suite.
+ *
+ * QA-08: zero violations at 320/375/414/768/1024 CSS px widths on Home /
+ * Blog Index / Blog Post, in both light and dark modes. Binary gate.
+ *
+ * Sources:
+ *  - docs/website/prd.md § QA-08 (WCAG 2.2 AA, wcag22aa ruleset)
+ *  - docs/website/ux-architecture.md § Mobile Accessibility + § Measurement Baseline
+ *  - PDR-006 § Measurement Baseline (mobile nav wrap, no hamburger)
+ *
+ * Tags union (`wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa`) is the
+ * cumulative WCAG 2.2 AA check — each newer revision adds rules rather than
+ * replacing the prior set. axe-core v4.7+ ships the `wcag22aa` rules.
+ *
+ * Dark-mode setup: the site reads `localStorage.theme` in an inline script
+ * in `BaseHead.astro` before first paint. We set it via
+ * `context.addInitScript` so there is no flash and no toggle click needed.
+ */
+import type { Result as AxeResult } from 'axe-core';
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from '@playwright/test';
+
+type Mode = 'light' | 'dark';
+
+interface Viewport {
+  readonly label: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+interface Target {
+  readonly label: string;
+  readonly path: string;
+}
+
+const VIEWPORTS: readonly Viewport[] = [
+  // 320 uses iPhone SE 1st-gen aspect per QA-09 convention.
+  { label: '320', width: 320, height: 568 },
+  { label: '375', width: 375, height: 667 },
+  { label: '414', width: 414, height: 896 },
+  { label: '768', width: 768, height: 1024 },
+  { label: '1024', width: 1024, height: 768 },
+];
+
+const TARGETS: readonly Target[] = [
+  { label: 'home', path: '/' },
+  { label: 'blog-index', path: '/blog/' },
+  // sample-post is the only published post at v1; if additional posts land,
+  // pick one explicitly — a11y scope is "at least one" per QA-08.
+  { label: 'blog-post', path: '/blog/sample-post/' },
+];
+
+const MODES: readonly Mode[] = ['light', 'dark'];
+
+const WCAG_TAGS = [
+  'wcag2a',
+  'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
+  'wcag22aa',
+] as const;
+
+for (const viewport of VIEWPORTS) {
+  for (const target of TARGETS) {
+    for (const mode of MODES) {
+      const title = `${target.label} @ ${viewport.label}px (${mode}) — no WCAG 2.2 AA violations`;
+
+      test(title, async ({ browser }) => {
+        const context = await browser.newContext({
+          viewport: { width: viewport.width, height: viewport.height },
+          colorScheme: mode,
+          reducedMotion: 'reduce',
+        });
+
+        // Pin the theme deterministically: matches BaseHead.astro's inline
+        // script, which runs pre-paint and reads `localStorage.theme`.
+        // Belt-and-suspenders with `colorScheme` above — prevents drift from
+        // OS-level prefers-color-scheme leaking through.
+        await context.addInitScript((m) => {
+          window.localStorage.setItem('theme', m);
+        }, mode);
+
+        const page = await context.newPage();
+
+        try {
+          await page.goto(target.path, { waitUntil: 'networkidle' });
+
+          // Sanity-check that theme actually applied. If this fails the
+          // axe result below would be scanning the wrong rendering, which
+          // would be misleading.
+          if (mode === 'dark') {
+            await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+          } else {
+            await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
+          }
+
+          const results = await new AxeBuilder({ page })
+            .withTags([...WCAG_TAGS])
+            .analyze();
+
+          const message = formatViolations(results.violations, {
+            viewport: viewport.label,
+            path: target.path,
+            mode,
+          });
+
+          expect(results.violations, message).toEqual([]);
+        } finally {
+          await context.close();
+        }
+      });
+    }
+  }
+}
+
+function formatViolations(
+  violations: AxeResult[],
+  ctx: { viewport: string; path: string; mode: Mode },
+): string {
+  if (violations.length === 0) {
+    return '';
+  }
+
+  const header = `axe-core found ${violations.length} violation(s) on ${ctx.path} @ ${ctx.viewport}px (${ctx.mode}):`;
+
+  const lines = violations.map((v, i) => {
+    const nodeCount = v.nodes.length;
+    const nodePreview = v.nodes
+      .slice(0, 3)
+      .map((n) => n.target.join(' '))
+      .join('\n       ');
+    return [
+      `  ${i + 1}. [${v.id}] ${v.help} — impact=${v.impact ?? 'n/a'}, nodes=${nodeCount}`,
+      `     ${v.helpUrl}`,
+      `     targets:\n       ${nodePreview}`,
+    ].join('\n');
+  });
+
+  return [header, ...lines].join('\n');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+/**
+ * Vitest configuration.
+ *
+ * Vitest's default include pattern (`**\/*.spec.ts`) would pick up
+ * Playwright specs under `tests/`, which use `@playwright/test` and
+ * call `test()` outside of Vitest's runner context. Excluding the
+ * Playwright dir keeps unit tests (`src/**\/*.test.ts`) and a11y tests
+ * (`tests/a11y/*.spec.ts`) on separate runners.
+ */
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, 'tests/**'],
+  },
+});


### PR DESCRIPTION
## Summary

Closes #96 (QA-08). Adds a binary-fail accessibility gate wired into the CI PR pipeline.

- **Scope**: 5 viewports (320/375/414/768/1024 CSS px) × 3 pages (`/`, `/blog/`, `/blog/sample-post/`) × 2 color modes = **30 test permutations**
- **Ruleset**: cumulative WCAG 2.2 AA via axe-core tags `wcag2a / wcag2aa / wcag21a / wcag21aa / wcag22aa` (axe-core 4.11.3, ≥ 4.7 supports 2.2 rules per PRD QA-08)
- **Gate**: CI step `A11y — axe-core WCAG 2.2 AA` runs after `build`; on failure uploads `test-results/` + `playwright-report/` as artifacts (14-day retention)

## Implementation notes

- **Dark-mode setup without FOUC**: `context.addInitScript` presets `localStorage.theme` before navigation; matches the inline theme script in `BaseHead.astro` which runs pre-paint. Belt-and-suspenders with Playwright's `colorScheme` context option.
- **Viewport heights** follow QA-09 conventions (320×568 for iPhone SE 1st gen, etc.).
- **Sample-post slug** is currently the only published post — if additional posts land, the test hard-codes one explicitly per AC-3 ("at least one `/blog/[slug]/`").

## Pre-existing violations surfaced by the gate

The gate is catching **2 real WCAG AA contrast failures** in merged Wave 1-3 code — **not in scope for #96** (which is the gate itself). All in **light mode** (dark mode passes cleanly: 15/30 green):

| Pair | Ratio | Needs | Components |
|---|---|---|---|
| `--color-muted` `#6b7280` on `--color-surface` `#f5f3ef` | **4.36:1** | 4.5:1 | `.tag-more`, `.toc-summary`, post-card metadata |
| `--color-accent` `#e85d2a` on `--color-bg` `#fafaf9` | **3.33:1** | 4.5:1 | `.cta-link` ("See all posts →") |

These are genuine failures that the PRD REQ-A11Y-06 anticipates but the implementation tickets didn't catch (no gate was in place when they merged). No parallel Wave 4 track addresses these — all four (#94/95/96/97) are gate/test infrastructure.

**Expected CI state for this PR: RED** (gate working as designed). Merge strategy for the orchestrator:
- (a) Land a follow-up fix for the two color pairs (separate ticket), then merge this, or
- (b) Merge this with the gate in place to establish the contract; the red gate on subsequent PRs forces the fix, or
- (c) Discuss scoping the color-token adjustment into this PR (would grow scope beyond #96)

## Test plan
- [x] `npx playwright test --list` — 30 tests enumerate correctly
- [x] Local run (Chromium): 15 pass (all dark), 15 fail (all light, pre-existing contrast)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — 0 errors / 0 warnings
- [ ] CI run on PR (red expected; see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)