### PR TITLE
(chore) remove frame-ancestors from meta CSP (#116)

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -87,10 +87,20 @@ const organizationSchema = Astro.site
     A future hardening step is to generate build-time hashes for the
     inline script and replace script-src 'unsafe-inline' with a hash
     allowlist.
+
+    `frame-ancestors` is intentionally omitted. Browsers ignore it when
+    delivered via <meta> (W3C CSP Level 3 § 3.3 — valid via HTTP header
+    only), and including it produces a console warning on every page
+    load. GitHub Pages cannot emit custom response headers, so
+    clickjacking protection is not enforceable on this host. If the site
+    migrates off GitHub Pages (see ADR-001 § Cloudflare Pages migration
+    option), add `X-Frame-Options: DENY` (or equivalent `frame-ancestors`
+    directive) via the destination's header mechanism — e.g. a
+    `public/_headers` file for Cloudflare Pages.
   -->
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+    content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self';"
   />
 
   <!-- Open Graph -->


### PR DESCRIPTION
## Summary

- Drop `frame-ancestors 'none';` from the meta CSP in `BaseHead.astro` — browsers ignore it when delivered via `<meta>` (W3C CSP Level 3 § 3.3), so the only effect was a console warning on every page load
- Keep every other directive (`default-src`, `script-src`, `style-src`, `font-src`, `img-src`, `connect-src`, `base-uri`, `form-action`) untouched
- Expand the existing CSP block comment to document: why `frame-ancestors` is intentionally omitted, the GitHub Pages constraint (no custom response headers), and the migration path (ADR-001 § Cloudflare Pages migration option → `public/_headers` + `X-Frame-Options: DENY`)

Closes #116.

## Scope

One file, +11/-1:

- `src/components/BaseHead.astro`

Single directive removed from the CSP `content` attribute; ADR-001 wording follows the file's existing decision-record convention (`See PDR-006 § Android web manifest.`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — 0 errors / 0 warnings
- [x] `npm run test` — 38/38 unit tests pass
- [x] `npm run build` — 5 pages build; inspected `dist/index.html`, `dist/blog/index.html`, `dist/about/index.html`, `dist/404.html` and confirmed the rendered `<meta http-equiv="Content-Security-Policy">` content attribute no longer contains `frame-ancestors`
- [ ] CI: QA-06 Lighthouse (mobile), QA-07 touch targets, QA-08 axe-core WCAG 2.2 AA, QA-09 visual regression — expected to pass (no rendering surface changes; only HTML comment and CSP directive payload changed)
- [ ] Post-deploy: confirm the recurring `The Content Security Policy directive 'frame-ancestors' is ignored when delivered via a <meta> element.` console warning is gone on `/`, `/blog/`, and `/about/`

Playwright and Lighthouse were intentionally not run locally — visual baselines are Linux-generated per `CONTRIBUTING.md § Visual regression baselines`, and the change class (CSP directive removal with no render impact) is better validated on CI's Linux runner.