### PR TITLE
(feat) QA-10.2 critical widths extractor + gate (#122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,27 @@ jobs:
           path: test-results/
           retention-days: 14
 
+      # QA-10.2 Critical widths audit (PDR-007 Phase 1). Pure-Node; no
+      # Playwright, no browser. Reads dist/_astro/*.css from the Build
+      # step above. Cross-cutting audit orchestration (cache reuse,
+      # unified report artifact, aggregator) lands in #127 alongside
+      # the QA-10.1 and QA-10.3 steps.
+      - name: QA-10.2 — Critical widths audit
+        run: node scripts/extract-widths.mjs
+
+      # Scoped to this audit's single report file to keep the artifact
+      # boundary explicit; #127 can replace this with a unified
+      # tests/audit/__reports__/*.json upload when QA-10.1 + QA-10.3
+      # land alongside.
+      - name: Upload QA-10.2 widths audit report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-10-2-widths-report
+          path: tests/audit/__reports__/widths-report.json
+          retention-days: 14
+          if-no-files-found: ignore
+
       # QA-06 Lighthouse mobile gates. Builds once at step above; LHCI
       # runs its own static server from ./dist, so no preview needed.
       - name: QA-06 — Lighthouse mobile gates

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ playwright/.cache/
 tests/visual/__baselines__/**/*-actual.png
 tests/visual/__baselines__/**/*-diff.png
 
+# QA-10.* audit per-run reports. The JSON artifact is captured by CI
+# on failure; nothing is committed. See PDR-007 / audit-tooling-design.
+tests/audit/__reports__/
+
 # Lighthouse CI run output
 .lighthouseci/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@playwright/test": "^1.59.1",
         "eslint": "^10.2.0",
         "eslint-plugin-astro": "^1.7.0",
+        "postcss": "8.5.8",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "astro check",
-    "check:playwright-version-parity": "node scripts/check-playwright-version-parity.mjs"
+    "check:playwright-version-parity": "node scripts/check-playwright-version-parity.mjs",
+    "test:audit:widths": "npm run build && node scripts/extract-widths.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
@@ -34,6 +35,7 @@
     "@playwright/test": "^1.59.1",
     "eslint": "^10.2.0",
     "eslint-plugin-astro": "^1.7.0",
+    "postcss": "8.5.8",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^5.9.3",

--- a/scripts/extract-widths.mjs
+++ b/scripts/extract-widths.mjs
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+// QA-10.2 Critical Widths extractor + gate.
+//
+// Pure-Node audit (no Playwright, no browser). Globs `dist/_astro/*.css`,
+// parses via postcss, walks every `@media` at-rule, and extracts each
+// `min-width` / `max-width` / `min-device-width` / `max-device-width` /
+// `min-resolution` threshold. Length units normalize to px at the 16px
+// root (em/rem × 16). Resolution thresholds keep their raw numeric
+// value (dppx ≠ dpi; no length axis). Thresholds are deduplicated
+// across files and sorted ascending for stable reporting.
+//
+// Classification:
+//   1. covered    — threshold ∈ QA-09 widths (tests/config/widths.ts)
+//   2. allowlisted — threshold ∈ tests/audit/threshold-significance.json
+//                    with review_by >= today
+//   3. unhandled  — fails the gate; the fail message names EACH
+//                    unhandled threshold, its source CSS file, and the
+//                    containing `@media` rule so the PR author can
+//                    classify in one glance (add to QA-09 widths, add
+//                    to allowlist with reason, or fix the CSS).
+//
+// Outputs:
+//   - Markdown report to stdout (captured by CI log).
+//   - JSON report to tests/audit/__reports__/widths-report.json (gitignored).
+//
+// Source-of-truth rule (issue #122 refinement, 2026-04-21):
+//   D = derived (CSS-authoritative for the audit direction).
+//   Q = QA-09 widths (MAY be a superset of D; emergent-layout widths
+//       without a CSS threshold are intentional and NOT audited).
+//   A = unexpired allowlist entries.
+//   Gate passes iff every d ∈ D satisfies d ∈ Q OR d ∈ A.
+//
+// See: PDR-007 § Decision Phase 1, § Constraints 5 (allowlist);
+//      audit-tooling-design.md § 2.2, § 5 Risk 5 (supply chain),
+//      § 6 Item 10 (npm script name). HQ repo, private;
+//      CONTRIBUTING.md § Cross-repo setup.
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+import postcss from 'postcss';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DIST_CSS_DIR = join(REPO_ROOT, 'dist/_astro');
+const WIDTHS_SOURCE = join(REPO_ROOT, 'tests/config/widths.ts');
+const ALLOWLIST_PATH = join(
+  REPO_ROOT,
+  'tests/audit/threshold-significance.json',
+);
+const REPORT_DIR = join(REPO_ROOT, 'tests/audit/__reports__');
+const REPORT_JSON = join(REPORT_DIR, 'widths-report.json');
+
+const MEDIA_FEATURES = new Set([
+  'min-width',
+  'max-width',
+  'min-device-width',
+  'max-device-width',
+  'min-resolution',
+]);
+
+/**
+ * Parse a single `@media` condition (the prelude string) into the
+ * list of threshold records it contributes. A prelude may combine
+ * multiple features with `and` / `or` / `,` / `not`; we extract each
+ * qualifying feature-value pair without trying to evaluate the
+ * overall query — the audit only cares about the thresholds named.
+ */
+export function parseMediaPrelude(prelude) {
+  const results = [];
+  // Match `(feature:value)` pairs. Tolerates whitespace inside the
+  // parens and around the colon. Captures feature and raw value.
+  const re = /\(\s*([a-z-]+)\s*:\s*([^)]+?)\s*\)/gi;
+  let m;
+  while ((m = re.exec(prelude)) !== null) {
+    const feature = m[1].toLowerCase();
+    if (!MEDIA_FEATURES.has(feature)) continue;
+    const rawValue = m[2].trim();
+    const normalized = normalizeThresholdValue(feature, rawValue);
+    if (normalized === null) continue;
+    results.push({
+      feature,
+      raw_value: rawValue,
+      threshold_px: normalized,
+    });
+  }
+  return results;
+}
+
+/**
+ * Normalize a media-feature value to a single numeric threshold.
+ *
+ * Length features (min/max-width, min/max-device-width):
+ *   px / bare-number → as-is; em / rem → value × 16 (16px root).
+ *   Other length units (cm, mm, pt, pc, in, vh, vw, …) are rejected
+ *   here — CI-built CSS from Astro consistently emits px, and
+ *   surfacing an unexpected unit as a parse failure is preferred to
+ *   silent mishandling.
+ *
+ * Resolution feature (min-resolution):
+ *   dppx / dpi / dpcm → preserved as the raw numeric value. The
+ *   audit compares as a number; a resolution threshold will never
+ *   collide with a width in Q, so the "common number" comparison is
+ *   safe in practice. Source and feature are preserved in the report
+ *   so the author sees the semantic distinction.
+ */
+export function normalizeThresholdValue(feature, rawValue) {
+  const match = rawValue.match(/^(-?[0-9]*\.?[0-9]+)\s*([a-z%]*)$/i);
+  if (!match) return null;
+  const n = parseFloat(match[1]);
+  const unit = match[2].toLowerCase();
+  if (!Number.isFinite(n)) return null;
+
+  if (feature === 'min-resolution') {
+    if (unit === 'dppx' || unit === 'dpi' || unit === 'dpcm' || unit === '') {
+      return n;
+    }
+    return null;
+  }
+
+  // Length features.
+  if (unit === 'px' || unit === '') return n;
+  if (unit === 'em' || unit === 'rem') return n * 16;
+  return null;
+}
+
+/**
+ * Walk a CSS source (string) via postcss and return every threshold
+ * it contributes. `sourceFile` is an arbitrary label stored on each
+ * record so failure messages can point the PR author at the offender.
+ */
+export function extractThresholds(cssContent, sourceFile) {
+  const root = postcss.parse(cssContent);
+  const out = [];
+  root.walkAtRules('media', (atRule) => {
+    const items = parseMediaPrelude(atRule.params);
+    for (const item of items) {
+      out.push({
+        ...item,
+        source_file: sourceFile,
+        media_condition: `@media ${atRule.params}`,
+      });
+    }
+  });
+  return out;
+}
+
+/**
+ * Load the QA-09 canonical widths from tests/config/widths.ts by
+ * text-scanning the exported array. A full TypeScript loader would
+ * require a compiler dependency; the file's shape is stable (single
+ * top-level numeric array) and the regex tolerates whitespace and
+ * trailing commas without needing a parser.
+ */
+export function loadWidths(sourceText) {
+  const match = sourceText.match(
+    /export\s+const\s+WIDTHS\s*=\s*\[([\s\S]*?)\]/,
+  );
+  if (!match) {
+    throw new Error(
+      `tests/config/widths.ts: could not locate 'export const WIDTHS = [...]'`,
+    );
+  }
+  const numbers = [];
+  for (const token of match[1].split(',')) {
+    const trimmed = token.trim();
+    if (trimmed === '') continue;
+    if (!/^-?[0-9]*\.?[0-9]+$/.test(trimmed)) {
+      // Non-numeric token (e.g., a comment that escaped a simple split);
+      // fail loud rather than silently skipping.
+      throw new Error(
+        `tests/config/widths.ts: unexpected non-numeric token '${trimmed}' in WIDTHS array`,
+      );
+    }
+    numbers.push(Number(trimmed));
+  }
+  if (numbers.length === 0) {
+    throw new Error(`tests/config/widths.ts: WIDTHS array parsed as empty`);
+  }
+  return numbers;
+}
+
+/**
+ * Classify each unique threshold against QA-09 widths and the
+ * allowlist. `today` is injected so tests can drive expired-entry
+ * behaviour deterministically.
+ *
+ * Returns a flat list of classified threshold records, each carrying
+ * its original source_file + media_condition trail. Thresholds that
+ * appear in multiple files produce multiple records — the caller
+ * aggregates for reporting.
+ */
+export function classifyThresholds(thresholds, widths, allowlist, today) {
+  const widthsSet = new Set(widths);
+  const allowByThreshold = new Map();
+  for (const entry of allowlist) {
+    allowByThreshold.set(entry.threshold_px, entry);
+  }
+
+  return thresholds.map((t) => {
+    if (widthsSet.has(t.threshold_px)) {
+      return { ...t, classification: 'covered' };
+    }
+    const allow = allowByThreshold.get(t.threshold_px);
+    if (allow) {
+      if (allow.review_by < today) {
+        return {
+          ...t,
+          classification: 'expired',
+          allow_entry: allow,
+        };
+      }
+      return { ...t, classification: 'allowlisted', allow_entry: allow };
+    }
+    return { ...t, classification: 'unhandled' };
+  });
+}
+
+function groupByThreshold(records) {
+  const map = new Map();
+  for (const r of records) {
+    const key = r.threshold_px;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(r);
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([threshold_px, recs]) => ({ threshold_px, records: recs }));
+}
+
+function todayISO() {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function renderMarkdown(summary, grouped) {
+  const lines = [];
+  lines.push('# QA-10.2 Critical Widths — audit report');
+  lines.push('');
+  lines.push(`- Run date: ${summary.run_date}`);
+  lines.push(`- CSS files scanned: ${summary.css_files_scanned}`);
+  lines.push(`- Unique thresholds derived: ${summary.unique_thresholds}`);
+  lines.push(`- Covered: ${summary.counts.covered}`);
+  lines.push(`- Allowlisted: ${summary.counts.allowlisted}`);
+  lines.push(`- Expired: ${summary.counts.expired}`);
+  lines.push(`- Unhandled: ${summary.counts.unhandled}`);
+  lines.push('');
+
+  if (grouped.length === 0) {
+    lines.push('_No media thresholds found in `dist/_astro/*.css`._');
+    return lines.join('\n');
+  }
+
+  lines.push('| Threshold | Classification | Feature(s) | Source(s) |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const g of grouped) {
+    const cls = g.records[0].classification;
+    const features = [...new Set(g.records.map((r) => r.feature))].join(', ');
+    const sources = [
+      ...new Set(
+        g.records.map((r) => `\`${r.source_file}\` — ${r.media_condition}`),
+      ),
+    ].join('<br>');
+    lines.push(`| ${g.threshold_px} | ${cls} | ${features} | ${sources} |`);
+  }
+  return lines.join('\n');
+}
+
+function renderFailureMessage(grouped) {
+  const failing = grouped.filter((g) =>
+    g.records.some(
+      (r) => r.classification === 'unhandled' || r.classification === 'expired',
+    ),
+  );
+  if (failing.length === 0) return '';
+
+  const lines = [];
+  lines.push('');
+  lines.push('QA-10.2 FAIL — unhandled media thresholds detected:');
+  lines.push('');
+  for (const g of failing) {
+    for (const r of g.records) {
+      if (r.classification !== 'unhandled' && r.classification !== 'expired') {
+        continue;
+      }
+      const suffix =
+        r.classification === 'expired'
+          ? ` [allowlist entry expired review_by=${r.allow_entry.review_by}]`
+          : '';
+      lines.push(`  - ${r.threshold_px}px (${r.feature})${suffix}`);
+      lines.push(`      source: ${r.source_file}`);
+      lines.push(`      rule:   ${r.media_condition}`);
+    }
+  }
+  lines.push('');
+  lines.push('Resolve each by one of:');
+  lines.push(
+    '  (a) add the threshold to tests/config/widths.ts (expands QA-09 widths; regenerate baselines),',
+  );
+  lines.push(
+    '  (b) add an entry to tests/audit/threshold-significance.json (with reason + review_by = today + 90d), or',
+  );
+  lines.push('  (c) fix the CSS so the threshold no longer appears.');
+  lines.push('See tests/audit/THRESHOLD-ALLOWLIST.md for lifecycle rules.');
+  return lines.join('\n');
+}
+
+/**
+ * Discover CSS files under `dist/_astro/`. A glob would pull in a
+ * dependency; a plain `readdirSync` with suffix filter matches the
+ * `dist/_astro/*.css` pattern from the AC without adding surface area.
+ */
+function globDistCss() {
+  let entries;
+  try {
+    entries = readdirSync(DIST_CSS_DIR, { withFileTypes: true });
+  } catch (err) {
+    throw new Error(
+      `${DIST_CSS_DIR}: cannot read (${err.code || err.message}). Run 'npm run build' first.`,
+    );
+  }
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.css'))
+    .map((e) => join(DIST_CSS_DIR, e.name))
+    .sort();
+}
+
+function loadAllowlist() {
+  let raw;
+  try {
+    raw = readFileSync(ALLOWLIST_PATH, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `${ALLOWLIST_PATH}: cannot read (${err.code || err.message})`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`${ALLOWLIST_PATH}: invalid JSON (${err.message})`);
+  }
+  if (!parsed || !Array.isArray(parsed.allowlist)) {
+    throw new Error(
+      `${ALLOWLIST_PATH}: expected { allowlist: [...] }; allowlist field is missing or not an array`,
+    );
+  }
+  return parsed.allowlist;
+}
+
+function writeJsonReport(summary, grouped) {
+  mkdirSync(REPORT_DIR, { recursive: true });
+  const payload = {
+    run_date: summary.run_date,
+    css_files_scanned: summary.css_files_scanned,
+    unique_thresholds: summary.unique_thresholds,
+    counts: summary.counts,
+    thresholds: grouped.map((g) => ({
+      threshold_px: g.threshold_px,
+      classification: g.records[0].classification,
+      features: [...new Set(g.records.map((r) => r.feature))].sort(),
+      // Dedupe by (source_file, feature, raw_value). Astro bundles
+      // multiple component styles into one CSS file, so identical
+      // @media rules can appear multiple times in a single file — the
+      // audit cares about whether the threshold is covered, not how
+      // many times it's written.
+      sources: dedupeSources(g.records),
+    })),
+  };
+  writeFileSync(REPORT_JSON, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+  return REPORT_JSON;
+}
+
+function dedupeSources(records) {
+  const seen = new Set();
+  const out = [];
+  for (const r of records) {
+    const key = `${r.source_file} ${r.feature} ${r.raw_value}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      source_file: r.source_file,
+      media_condition: r.media_condition,
+      feature: r.feature,
+      raw_value: r.raw_value,
+    });
+  }
+  return out;
+}
+
+export async function main() {
+  const today = todayISO();
+
+  const widths = loadWidths(readFileSync(WIDTHS_SOURCE, 'utf8'));
+  const allowlist = loadAllowlist();
+  const cssFiles = globDistCss();
+
+  const allThresholds = [];
+  for (const file of cssFiles) {
+    const content = readFileSync(file, 'utf8');
+    const rel = relative(REPO_ROOT, file);
+    for (const t of extractThresholds(content, rel)) {
+      allThresholds.push(t);
+    }
+  }
+
+  const classified = classifyThresholds(
+    allThresholds,
+    widths,
+    allowlist,
+    today,
+  );
+
+  // Collapse to one record per (threshold_px, classification). The
+  // classification is a function of the threshold alone, so all records
+  // for a given threshold share the same classification — the grouping
+  // just preserves the source trail.
+  const grouped = groupByThreshold(classified);
+
+  const counts = {
+    covered: 0,
+    allowlisted: 0,
+    expired: 0,
+    unhandled: 0,
+  };
+  for (const g of grouped) {
+    counts[g.records[0].classification] += 1;
+  }
+
+  const summary = {
+    run_date: today,
+    css_files_scanned: cssFiles.length,
+    unique_thresholds: grouped.length,
+    counts,
+  };
+
+  // Markdown report to stdout (CI log capture).
+  process.stdout.write(renderMarkdown(summary, grouped) + '\n');
+
+  // JSON report to gitignored __reports__/.
+  const jsonPath = writeJsonReport(summary, grouped);
+  process.stdout.write(`\nJSON report: ${relative(REPO_ROOT, jsonPath)}\n`);
+
+  const failMsg = renderFailureMessage(grouped);
+  if (failMsg !== '') {
+    process.stderr.write(failMsg + '\n');
+    process.exit(1);
+  }
+}
+
+// CLI invocation — only runs when executed directly, not when imported
+// by the unit test.
+const isCli = process.argv[1] === fileURLToPath(import.meta.url);
+if (isCli) {
+  main().catch((err) => {
+    process.stderr.write(`[extract-widths] ERROR: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/extract-widths.test.mjs
+++ b/scripts/extract-widths.test.mjs
@@ -1,0 +1,264 @@
+// Unit tests for scripts/extract-widths.mjs (QA-10.2 critical widths
+// extractor + gate). Drives classification and parsing logic through
+// in-memory CSS fixtures so the reverse-test AC (introducing a new
+// `@media (min-width: 851px)` rule is surfaced as unhandled with source
+// file named) has an automated enforcement point.
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseMediaPrelude,
+  normalizeThresholdValue,
+  extractThresholds,
+  loadWidths,
+  classifyThresholds,
+} from './extract-widths.mjs';
+
+describe('normalizeThresholdValue', () => {
+  it('passes bare pixel values through', () => {
+    expect(normalizeThresholdValue('min-width', '480px')).toBe(480);
+    expect(normalizeThresholdValue('max-width', '639px')).toBe(639);
+  });
+
+  it('normalizes em/rem to px at 16px root', () => {
+    expect(normalizeThresholdValue('min-width', '30em')).toBe(480);
+    expect(normalizeThresholdValue('min-width', '48rem')).toBe(768);
+  });
+
+  it('accepts bare numbers for length features', () => {
+    expect(normalizeThresholdValue('min-width', '480')).toBe(480);
+  });
+
+  it('returns null for unsupported length units', () => {
+    expect(normalizeThresholdValue('min-width', '30vh')).toBeNull();
+    expect(normalizeThresholdValue('min-width', '300pt')).toBeNull();
+  });
+
+  it('preserves raw numeric value for min-resolution', () => {
+    expect(normalizeThresholdValue('min-resolution', '2dppx')).toBe(2);
+    expect(normalizeThresholdValue('min-resolution', '192dpi')).toBe(192);
+    expect(normalizeThresholdValue('min-resolution', '75dpcm')).toBe(75);
+  });
+
+  it('rejects invalid numeric input', () => {
+    expect(normalizeThresholdValue('min-width', 'abc')).toBeNull();
+    expect(normalizeThresholdValue('min-width', '')).toBeNull();
+  });
+});
+
+describe('parseMediaPrelude', () => {
+  it('extracts a single feature', () => {
+    expect(parseMediaPrelude('(min-width: 480px)')).toEqual([
+      { feature: 'min-width', raw_value: '480px', threshold_px: 480 },
+    ]);
+  });
+
+  it('extracts multiple features combined with and', () => {
+    const out = parseMediaPrelude('(min-width: 480px) and (max-width: 767px)');
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ feature: 'min-width', threshold_px: 480 });
+    expect(out[1]).toMatchObject({ feature: 'max-width', threshold_px: 767 });
+  });
+
+  it('ignores unrelated media features', () => {
+    expect(parseMediaPrelude('(orientation: landscape)')).toEqual([]);
+    expect(
+      parseMediaPrelude('screen and (prefers-color-scheme: dark)'),
+    ).toEqual([]);
+  });
+
+  it('tolerates whitespace variants', () => {
+    expect(parseMediaPrelude('(  min-width : 480px  )')).toEqual([
+      { feature: 'min-width', raw_value: '480px', threshold_px: 480 },
+    ]);
+  });
+
+  it('extracts min-resolution alongside width features', () => {
+    const out = parseMediaPrelude(
+      '(min-width: 1024px) and (min-resolution: 2dppx)',
+    );
+    expect(out).toHaveLength(2);
+    expect(out.find((t) => t.feature === 'min-resolution')).toMatchObject({
+      threshold_px: 2,
+    });
+  });
+});
+
+describe('extractThresholds', () => {
+  it('walks @media at-rules in a CSS string', () => {
+    const css = `
+      .a { color: red; }
+      @media (min-width: 480px) { .a { color: blue; } }
+      @media (max-width: 639px) { .a { color: green; } }
+    `;
+    const out = extractThresholds(css, 'fixture.css');
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({
+      feature: 'min-width',
+      threshold_px: 480,
+      source_file: 'fixture.css',
+      media_condition: '@media (min-width: 480px)',
+    });
+    expect(out[1]).toMatchObject({
+      feature: 'max-width',
+      threshold_px: 639,
+      source_file: 'fixture.css',
+    });
+  });
+
+  it('returns empty array when no @media rules are present', () => {
+    const css = '.a { color: red; } .b { color: blue; }';
+    expect(extractThresholds(css, 'fixture.css')).toEqual([]);
+  });
+
+  it('handles nested at-rules and multiple queries per file', () => {
+    const css = `
+      @media (min-width: 480px), (min-width: 768px) { .a { color: red; } }
+      @media (min-width: 1024px) { .a { color: blue; } }
+    `;
+    const out = extractThresholds(css, 'fixture.css');
+    // Three thresholds: 480, 768 (same @media rule, comma-combined) and 1024.
+    expect(out.map((t) => t.threshold_px).sort((a, b) => a - b)).toEqual([
+      480, 768, 1024,
+    ]);
+  });
+});
+
+describe('loadWidths', () => {
+  it('parses a canonical widths.ts file', () => {
+    const source = `
+      /** doc */
+      export const WIDTHS = [
+        320, 375, 414, 480, 500, 600, 640, 700, 767, 768, 1024, 1440,
+      ] as const;
+    `;
+    expect(loadWidths(source)).toEqual([
+      320, 375, 414, 480, 500, 600, 640, 700, 767, 768, 1024, 1440,
+    ]);
+  });
+
+  it('throws when the export is missing', () => {
+    expect(() => loadWidths('const OTHER = [1, 2, 3];')).toThrow(
+      /could not locate/,
+    );
+  });
+
+  it('throws on unexpected non-numeric tokens in the array', () => {
+    expect(() =>
+      loadWidths('export const WIDTHS = [320, "oops", 480];'),
+    ).toThrow(/non-numeric token/);
+  });
+
+  it('throws when the array is empty', () => {
+    expect(() => loadWidths('export const WIDTHS = [];')).toThrow(
+      /parsed as empty/,
+    );
+  });
+});
+
+describe('classifyThresholds', () => {
+  const today = '2026-04-21';
+  const widths = [480, 640, 768, 1024];
+
+  it('classifies covered thresholds', () => {
+    const thresholds = [
+      {
+        feature: 'min-width',
+        raw_value: '480px',
+        threshold_px: 480,
+        source_file: 'dist/_astro/x.css',
+        media_condition: '@media (min-width: 480px)',
+      },
+    ];
+    const out = classifyThresholds(thresholds, widths, [], today);
+    expect(out[0].classification).toBe('covered');
+  });
+
+  it('classifies allowlisted thresholds with unexpired review_by', () => {
+    const thresholds = [
+      {
+        feature: 'max-width',
+        raw_value: '639px',
+        threshold_px: 639,
+        source_file: 'dist/_astro/x.css',
+        media_condition: '@media (max-width: 639px)',
+      },
+    ];
+    const allowlist = [
+      {
+        threshold_px: 639,
+        reason: 'test',
+        source_file: 'dist/_astro/x.css',
+        added: '2026-04-21',
+        review_by: '2026-07-20',
+      },
+    ];
+    const out = classifyThresholds(thresholds, widths, allowlist, today);
+    expect(out[0].classification).toBe('allowlisted');
+    expect(out[0].allow_entry.reason).toBe('test');
+  });
+
+  it('classifies allowlisted entries as expired when review_by is past', () => {
+    const thresholds = [
+      {
+        feature: 'max-width',
+        raw_value: '639px',
+        threshold_px: 639,
+        source_file: 'x.css',
+        media_condition: '@media (max-width: 639px)',
+      },
+    ];
+    const allowlist = [
+      {
+        threshold_px: 639,
+        reason: 'test',
+        source_file: 'x.css',
+        added: '2026-01-01',
+        review_by: '2026-04-01',
+      },
+    ];
+    const out = classifyThresholds(thresholds, widths, allowlist, today);
+    expect(out[0].classification).toBe('expired');
+  });
+
+  it('classifies absent thresholds as unhandled', () => {
+    const thresholds = [
+      {
+        feature: 'min-width',
+        raw_value: '851px',
+        threshold_px: 851,
+        source_file: 'x.css',
+        media_condition: '@media (min-width: 851px)',
+      },
+    ];
+    const out = classifyThresholds(thresholds, widths, [], today);
+    expect(out[0].classification).toBe('unhandled');
+  });
+});
+
+// The reverse-test AC from issue #122: introducing a new
+// `@media (min-width: 851px)` rule in a test CSS fixture must be
+// surfaced as an unhandled threshold with the source file named.
+describe('reverse-test (issue #122 AC)', () => {
+  it('surfaces a new @media (min-width: 851px) rule as unhandled with source file', () => {
+    const css = `
+      .a { color: red; }
+      @media (min-width: 851px) {
+        .a { color: blue; }
+      }
+    `;
+    const thresholds = extractThresholds(css, 'dist/_astro/fixture.css');
+    const classified = classifyThresholds(
+      thresholds,
+      [320, 375, 414, 480, 500, 600, 640, 700, 767, 768, 1024, 1440],
+      [],
+      '2026-04-21',
+    );
+
+    const hit = classified.find((r) => r.threshold_px === 851);
+    expect(hit).toBeDefined();
+    expect(hit.classification).toBe('unhandled');
+    expect(hit.source_file).toBe('dist/_astro/fixture.css');
+    expect(hit.media_condition).toBe('@media (min-width: 851px)');
+    expect(hit.feature).toBe('min-width');
+  });
+});

--- a/tests/audit/threshold-significance.json
+++ b/tests/audit/threshold-significance.json
@@ -1,4 +1,12 @@
 {
   "$schema": "./threshold-significance.schema.json",
-  "allowlist": []
+  "allowlist": [
+    {
+      "threshold_px": 639,
+      "reason": "Lower-bound-exclusive pair to QA-09's min-width:640 at Footer.astro mobile-collapse layout (PDR-006 § Mobile § Footer). QA-09 already baselines 320-600 (mobile-stacked) and 640+ (desktop-row); the 639 boundary is a CSS implementation detail with no independent layout state.",
+      "source_file": "dist/_astro/about.TrGEe_8_.css",
+      "added": "2026-04-21",
+      "review_by": "2026-07-20"
+    }
+  ]
 }

--- a/tests/config/widths.ts
+++ b/tests/config/widths.ts
@@ -1,0 +1,27 @@
+/**
+ * Canonical viewport widths (CSS px) for the QA-09 visual-regression gate
+ * and the QA-10.2 / QA-10.6 audit gates that share the same width surface.
+ *
+ * Source of truth. Consumed by:
+ *   - tests/visual/screenshots.spec.ts (QA-09 pixel-diff baselines)
+ *   - scripts/extract-widths.mjs      (QA-10.2 critical-widths audit)
+ *   - tests/visual/rendering-modes.spec.ts (QA-10.6, when Phase 3 lands)
+ *
+ * Widths span the PDR-006 mobile-through-desktop coverage, including the
+ * 480-767 collapse band (the range where Pattern A's single-row nav is
+ * emergent rather than enforced). PDR-006 constraint 6 made this band
+ * required coverage after the PR #99 B1 regression revealed untested
+ * assumptions about 480px single-row behavior.
+ *
+ * QA-10.2 semantics: QA-09 MAY be a superset of thresholds the CSS
+ * actually uses. Widths here that are absent from `dist/_astro/*.css`
+ * media queries (e.g., 500/600/700, added for emergent-layout coverage)
+ * are NOT audited against the CSS-derived set — they exist for visual-
+ * regression signal. See PDR-007 § Decision Phase 1 and the 2026-04-21
+ * refinement on #122 for the authoritative one-directional rule.
+ */
+export const WIDTHS = [
+  320, 375, 414, 480, 500, 600, 640, 700, 767, 768, 1024, 1440,
+] as const;
+
+export type Width = (typeof WIDTHS)[number];

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -21,7 +21,7 @@ Playwright screenshot baselines for QA-09 (see `hq/docs/website/prd.md` § QA-09
 
 ### What this guards
 
-- **Layout regressions** at the 12 viewport widths that matter for HDIAI: `320, 375, 414, 480, 500, 600, 640, 700, 767, 768, 1024, 1440` (CSS px).
+- **Layout regressions** at the 12 viewport widths that matter for HDIAI: `320, 375, 414, 480, 500, 600, 640, 700, 767, 768, 1024, 1440` (CSS px). Canonical source: [`tests/config/widths.ts`](../config/widths.ts) — consumed by `tests/visual/screenshots.spec.ts` (QA-09) and `scripts/extract-widths.mjs` (QA-10.2) to prevent drift.
 - **Dark-mode parity**: every width is captured in both light and dark color schemes.
 - **Three canonical surfaces**: `/` (home), `/blog/` (blog index), `/blog/sample-post/` (a blog post) — representing the three layout archetypes the site serves.
 - The **480–767 collapse band** specifically — per PDR-006 constraint 6 (see `hq/docs/website/prd.md#qa-09-mobile-visual-regression`) and the 2026-04-19 amendment. This is the width range where Pattern A single-row navigation is emergent rather than enforced; the B1 regression in PR #99 came from untested assumptions here.

--- a/tests/visual/screenshots.spec.ts
+++ b/tests/visual/screenshots.spec.ts
@@ -16,11 +16,7 @@
  * review so any intended visual shift is explicitly approved.
  */
 import { test, expect } from '@playwright/test';
-
-/** Viewport widths (CSS px). See PRD § QA-09 / PDR-006 constraint 6. */
-const WIDTHS = [
-  320, 375, 414, 480, 500, 600, 640, 700, 767, 768, 1024, 1440,
-] as const;
+import { WIDTHS } from '../config/widths';
 
 type Mode = 'light' | 'dark';
 const MODES: readonly Mode[] = ['light', 'dark'] as const;


### PR DESCRIPTION
## Summary

PDR-007 Phase 1 component QA-10.2. Pure-Node audit that derives the
critical-widths check directly from built CSS so the QA-09 visual-
regression width list cannot silently under-cover the surface it's
supposed to gate.

- `scripts/extract-widths.mjs` globs `dist/_astro/*.css`, parses via
  `postcss`, walks every `@media` at-rule, and extracts each
  `min-width` / `max-width` / `min/max-device-width` / `min-resolution`
  threshold (em/rem → px at 16px root; deduplicated; sorted).
- Classifies each threshold as **covered** (in QA-09 widths),
  **allowlisted** (with unexpired `review_by`), **expired** (past
  `review_by` — fails), or **unhandled** (fails). Fail message names
  each offending threshold, its source CSS file, and the containing
  `@media` rule, plus the three remediation paths (add to widths,
  allowlist with reason, or fix the CSS).
- Markdown report to stdout (CI log); JSON report to
  `tests/audit/__reports__/widths-report.json` (gitignored, uploaded
  as CI artifact).
- Refactor: `WIDTHS` extracted from `tests/visual/screenshots.spec.ts`
  into shared `tests/config/widths.ts` — QA-09 and QA-10.2 now share
  one source of truth, as will QA-10.6 (#134).
- CI step wired after the Playwright suite upload; reads `dist/`
  produced by the existing Build step (no duplicate build).

### Source-of-truth rule (issue #122 refinement)

The audit check is **one-directional**: `D` (CSS-derived thresholds)
must be a subset of `Q` (QA-09 widths) ∪ `A` (unexpired allowlist).
`Q` MAY legitimately exceed `D` — PDR-006 constraint 6's emergent-
layout widths (e.g., the 500/600/700 collapse-band coverage) have no
CSS counterpart by design and are NOT audited against `D`. Prevents
the failure mode PDR-007 was adopted to address.

### Allowlist entry added

`639px` — lower-bound-exclusive pair to QA-09's `min-width:640` at
`Footer.astro` mobile-collapse (PDR-006 § Mobile § Footer). Widths
320-600 (mobile-stacked) and 640+ (desktop-row) are already
baselined; the 639 boundary has no independent layout state. Review
date: 2026-07-20 (+90d).

### Dependencies

- `postcss@8.5.8` — pinned direct (not `^`) per PDR-007 Constraint 5
  / audit-tooling-design § 5 Risk 5 (supply-chain mitigation). Already
  present transitively via Astro/Vite; the direct pin makes intent
  explicit and deduplicates to a single version.

### Scope boundary

Cross-cutting audit orchestration — unified report artifact, cache
reuse, Phase 1 aggregator — lands in #127 alongside QA-10.1 (#120)
and QA-10.3 (#121) steps. The artifact upload added here is scoped
to `widths-report.json` only; #127 can replace it with the design
doc's `*.json` glob when the other Phase 1 components are wired.

## Acceptance criteria

- [x] `scripts/extract-widths.mjs` — pure Node + postcss, all five
      media-feature types, em/rem normalization, dedupe + sort.
- [x] Refactor WIDTHS into `tests/config/widths.ts`;
      `screenshots.spec.ts` imports from it.
- [x] Script loads QA-09 widths AND allowlist.
- [x] Classification: covered / allowlisted / expired / unhandled.
- [x] Fail message names threshold, source file, containing @media.
- [x] Markdown report to stdout; JSON report to gitignored
      `tests/audit/__reports__/widths-report.json`.
- [x] `postcss` pinned direct dev-dep (no `^`).
- [x] `test:audit:widths` npm script per design doc § 6 Item 10.
- [x] CI step wired (coordinated with #127).
- [x] Reverse-test unit test: new `@media (min-width: 851px)` is
      surfaced as unhandled with source file named.

## Test plan

- [x] `npm run test` — 61 tests pass across 5 files (includes the
      reverse-test AC).
- [x] `npm run typecheck` — 0 errors, 0 warnings.
- [x] `npm run lint` — clean.
- [x] `npm run test:audit:widths` — 3 thresholds derived (480
      covered, 768 covered, 639 allowlisted), exits 0.
- [x] Adversarial: removing the 639 allowlist entry locally causes
      the script to exit 1 with the expected fail message naming
      `639px (max-width) / source: dist/_astro/about.TrGEe_8_.css /
      rule: @media (max-width:639px)`.
- [ ] CI green on this PR (verified on merge).

## Related

- Closes #122.
- Consumes #119 (allowlist scaffolding — merged).
- Coordinated with #127 (Phase 1 CI orchestration).
- Unblocks #134 (QA-10.6 Rendering Modes) via shared
  `tests/config/widths.ts`.
- PDR-007 § Decision Phase 1; § Constraints 5 (allowlist);
  audit-tooling-design § 2.2, § 5 Risk 5, § 6 Item 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)