### PR TITLE
(feat) QA-10.1 route clustering via sitemap walk + DOM skeleton hash (#120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,9 @@ jobs:
         run: npm run build
 
       # Playwright-driven gates: QA-09 visual regression +
-      # QA-08 axe-core WCAG 2.2 AA + QA-07 touch-target audit.
-      # A single `playwright test` invocation covers all three
+      # QA-08 axe-core WCAG 2.2 AA + QA-07 touch-target audit +
+      # QA-10.1 route clustering (PDR-007 Phase 1 audit tooling).
+      # A single `playwright test` invocation covers all four
       # suites because projects in playwright.config.ts use
       # testMatch to route specs to the right project(s).
       - name: Get Playwright version
@@ -69,7 +70,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
-      - name: QA-07 / QA-08 / QA-09 — Playwright suites
+      - name: QA-07 / QA-08 / QA-09 / QA-10.1 — Playwright suites
         run: npx playwright test
 
       - name: Upload Playwright HTML report

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:visual:update": "npm run build && playwright test tests/visual --update-snapshots",
     "test:a11y": "npm run build && playwright test tests/a11y",
     "test:touch-targets": "npm run build && playwright test tests/a11y/touch-targets.spec.ts",
+    "test:audit:routes": "npm run build && playwright test --project=audit-routes",
+    "test:audit:routes:update": "npm run build && UPDATE_BASELINE=1 playwright test --project=audit-routes",
     "test:lighthouse": "npm run build && lhci autorun",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,23 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Unified Playwright configuration for QA-07 / QA-08 / QA-09.
+ * Unified Playwright configuration for QA-07 / QA-08 / QA-09 / QA-10.1.
  *
- * Three test suites share this config and one `astro preview` webServer:
+ * Four test suites share this config and one `astro preview` webServer:
  *   - `tests/visual/**`        — QA-09 visual regression baselines.
  *   - `tests/a11y/axe.spec.ts` — QA-08 axe-core WCAG 2.2 AA (drives its
  *                                own viewports / color-modes in-code).
  *   - `tests/a11y/touch-targets.spec.ts` — QA-07 touch-target audit
  *                                (uses the project's viewport directly).
+ *   - `tests/audit/routes.spec.ts`       — QA-10.1 route clustering via
+ *                                sitemap walk + DOM skeleton hash (per
+ *                                PDR-007 Phase 1; shares the Desktop Chrome
+ *                                device with the visual suite).
  *
- * Visual + axe run in a single chromium project (Desktop Chrome device
- * metrics); touch-targets runs once per mobile viewport because its spec
- * reads the viewport from the project, not from in-spec iteration.
+ * Visual + axe + audit-routes run in chromium projects (Desktop Chrome
+ * device metrics); touch-targets runs once per mobile viewport because
+ * its spec reads the viewport from the project, not from in-spec
+ * iteration.
  *
  * Per `tests/visual/README.md`: snapshotPathTemplate keeps baselines at
  * `tests/visual/__baselines__/` regardless of the new `./tests` testDir.
@@ -52,6 +57,11 @@ export default defineConfig({
     {
       name: 'chromium',
       testMatch: /(visual\/.*|a11y\/axe)\.spec\.ts$/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'audit-routes',
+      testMatch: /audit\/routes\.spec\.ts$/,
       use: { ...devices['Desktop Chrome'] },
     },
     ...MOBILE_VIEWPORTS.map((v) => ({

--- a/tests/audit/__baselines__/route-clusters.json
+++ b/tests/audit/__baselines__/route-clusters.json
@@ -1,0 +1,36 @@
+{
+  "archetypes": {
+    "home": {
+      "skeleton_hash": "d29359e95ba4c4855ad100ac5311ce3a0d399a12626e946eb9c55b2768dabc67",
+      "canonical_path": "/",
+      "registered": "2026-04-21"
+    },
+    "blog-index": {
+      "skeleton_hash": "b9d088dfde0254e1dccc7dffa7ba856e440c8f9678018525f3270eac04efcad7",
+      "canonical_path": "/blog/",
+      "registered": "2026-04-21"
+    },
+    "blog-post": {
+      "skeleton_hash": "088aec23695bd23b178fe37d3907de1272d88b934e90455aecdcc95287a86d52",
+      "canonical_path": "/blog/sample-post/",
+      "registered": "2026-04-21"
+    },
+    "about": {
+      "skeleton_hash": "822e794ba73d0a5ce32972a864cf0e0509e109b4ce2e83c25754347d32c4ab5f",
+      "canonical_path": "/about/",
+      "registered": "2026-04-21"
+    },
+    "error": {
+      "skeleton_hash": "24ea3a7f269282377959c8922ac75798c535623990e821ea3da7037a7dd0777a",
+      "canonical_path": "/404.html",
+      "registered": "2026-04-21"
+    }
+  },
+  "route_assignments": {
+    "/": "home",
+    "/blog/": "blog-index",
+    "/blog/sample-post/": "blog-post",
+    "/about/": "about",
+    "/404.html": "error"
+  }
+}

--- a/tests/audit/routes.spec.ts
+++ b/tests/audit/routes.spec.ts
@@ -1,0 +1,368 @@
+/**
+ * QA-10.1 — Route clustering via sitemap walk + DOM skeleton hash (Phase 1).
+ *
+ * Enumerates every route in the built sitemap (`dist/sitemap-index.xml` +
+ * `dist/sitemap-0.xml`) plus any route explicitly registered in the
+ * baseline's `route_assignments`. For each route, extracts the canonical
+ * DOM skeleton inside `<main>` (tag + sorted lowercase classes + children,
+ * recursively), SHA-256 hashes the canonical JSON, and fails when:
+ *
+ *   (a) a route's hash is not a registered archetype AND the route is not
+ *       explicitly registered in `route_assignments` (unregistered route),
+ *       OR
+ *   (b) a route is registered under one archetype but its hash matches a
+ *       DIFFERENT archetype's reference (category drift).
+ *
+ * Exact skeleton-hash matching — explicitly not similarity-based
+ * clustering (see PDR-007 § Decision Phase 1; audit-tooling-design § 5
+ * Risk 2). The tunable is the normalization performed by the walker
+ * (what it strips vs keeps), not a distance threshold.
+ *
+ * Sources:
+ *  - PDR-007 § Decision Phase 1 (HQ repo; private)
+ *  - audit-tooling-design.md § 2.1 (HQ repo; private)
+ *  - Archetype decisions resolved at 2026-04-21 refinement, captured in
+ *    GitHub issue #120 description.
+ *
+ * Baseline regeneration is authoritative in the Playwright Linux Docker
+ * image — see `tests/visual/README.md` § Baselines must be Linux-generated.
+ * Run `UPDATE_BASELINE=1 npm run test:audit:routes` inside the container
+ * to refresh `tests/audit/__baselines__/route-clusters.json`.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from '@playwright/test';
+
+const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = dirname(dirname(TESTS_DIR));
+const DIST_DIR = join(REPO_ROOT, 'dist');
+const BASELINE_PATH = join(TESTS_DIR, '__baselines__', 'route-clusters.json');
+const REPORT_DIR = join(TESTS_DIR, '__reports__');
+const REPORT_PATH = join(REPORT_DIR, 'routes-report.json');
+
+// UPDATE_BASELINE=1 refreshes committed archetype hashes from the current
+// build. In-flight (never-registered) routes still fail to keep the
+// human-in-the-loop archetype-registration step explicit.
+const UPDATE_BASELINE = process.env.UPDATE_BASELINE === '1';
+
+interface Archetype {
+  skeleton_hash: string;
+  canonical_path: string;
+  registered: string;
+}
+
+interface Baseline {
+  archetypes: Record<string, Archetype>;
+  route_assignments: Record<string, string>;
+}
+
+interface SkeletonNode {
+  tag: string;
+  classes: string[];
+  children: SkeletonNode[];
+}
+
+type RouteSource = 'sitemap' | 'registered' | 'both';
+
+interface RouteResult {
+  route: string;
+  source: RouteSource;
+  registered_archetype: string | null;
+  actual_hash: string;
+  expected_hash: string | null;
+  matches: boolean;
+  drift_archetype: string | null;
+}
+
+function readBaseline(): Baseline {
+  if (!existsSync(BASELINE_PATH)) {
+    throw new Error(
+      `Baseline missing: ${BASELINE_PATH}\n` +
+        `Create the baseline with initial archetypes and regenerate hashes ` +
+        `via UPDATE_BASELINE=1 npm run test:audit:routes inside the ` +
+        `Playwright Linux Docker container.`,
+    );
+  }
+  const raw = readFileSync(BASELINE_PATH, 'utf8');
+  const parsed = JSON.parse(raw) as Partial<Baseline>;
+  if (!parsed.archetypes || !parsed.route_assignments) {
+    throw new Error(
+      `Baseline ${BASELINE_PATH} is malformed: missing "archetypes" or ` +
+        `"route_assignments".`,
+    );
+  }
+  return parsed as Baseline;
+}
+
+/**
+ * Parse `<loc>...</loc>` values from a sitemap XML file.
+ *
+ * Regex-based rather than a full XML parser — `@astrojs/sitemap` emits
+ * stable, unescaped URLs inside flat `<loc>` tags. Matches the vanilla-Node
+ * discipline of other audit-tooling scripts (`check-playwright-version-parity.mjs`),
+ * avoids pulling in an XML parser for a trivial extraction.
+ */
+function parseSitemapLocs(filePath: string): string[] {
+  if (!existsSync(filePath)) {
+    throw new Error(
+      `Sitemap file missing: ${filePath}. Did the build run first? ` +
+        `Run \`npm run build\` before invoking this spec, or use the ` +
+        `\`test:audit:routes\` script which chains build + test.`,
+    );
+  }
+  const content = readFileSync(filePath, 'utf8');
+  const matches = [...content.matchAll(/<loc>([^<]+)<\/loc>/g)];
+  return matches.map((m) => m[1]);
+}
+
+/**
+ * Walk sitemap-index → per-sitemap files → URLs, returning pathnames.
+ *
+ * `@astrojs/sitemap` emits absolute URLs (https://how-do-i.ai/...); we
+ * strip the origin and keep the pathname only, because Playwright's
+ * `page.goto` resolves relative paths against `use.baseURL` (the preview
+ * server), not the production origin.
+ */
+function collectSitemapRoutes(distDir: string): string[] {
+  const indexPath = join(distDir, 'sitemap-index.xml');
+  const sitemapUrls = parseSitemapLocs(indexPath);
+
+  const routes: string[] = [];
+  for (const sitemapUrl of sitemapUrls) {
+    // sitemap-index entries are themselves absolute URLs pointing to
+    // per-sitemap files. Extract just the filename to locate the file
+    // on disk in `dist/`.
+    const filename = sitemapUrl.split('/').pop();
+    if (!filename) {
+      throw new Error(`Sitemap index entry has no filename: ${sitemapUrl}`);
+    }
+    const sitemapFilePath = join(distDir, filename);
+    for (const urlStr of parseSitemapLocs(sitemapFilePath)) {
+      routes.push(new URL(urlStr).pathname);
+    }
+  }
+  return routes;
+}
+
+function hashSkeleton(skeleton: SkeletonNode): string {
+  // Object keys are emitted in insertion order by Node's JSON.stringify, and
+  // extractSkeleton constructs nodes with fixed key order (tag, classes,
+  // children), so the serialized form is deterministic without needing a
+  // custom canonicalizer.
+  const canonical = JSON.stringify(skeleton);
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+function findMatchingArchetype(
+  hash: string,
+  archetypes: Record<string, Archetype>,
+  excludeName: string | null = null,
+): string | null {
+  for (const [name, archetype] of Object.entries(archetypes)) {
+    if (name === excludeName) continue;
+    if (archetype.skeleton_hash === hash) return name;
+  }
+  return null;
+}
+
+// Tests share the `results` array via closure and write the aggregated
+// report in afterAll — serial mode keeps every test in the same worker
+// so the shared array is consistent. The audit is fast (five routes),
+// and parallelization here would save ~1s for significantly less robust
+// reporting.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('QA-10.1 Route Clustering', () => {
+  const baseline = readBaseline();
+  const sitemapRoutes = collectSitemapRoutes(DIST_DIR);
+  const sitemapRouteSet = new Set(sitemapRoutes);
+  const registeredRouteSet = new Set(Object.keys(baseline.route_assignments));
+
+  // Test UNION: sitemap routes catch newly-added pages (fail as unregistered
+  // until someone updates route_assignments); registered routes catch
+  // explicitly-tracked non-sitemap surfaces (/404.html, not in sitemap
+  // because error pages shouldn't be indexed).
+  const allRoutes = Array.from(
+    new Set([...sitemapRouteSet, ...registeredRouteSet]),
+  ).sort();
+
+  const results: RouteResult[] = [];
+
+  test.afterAll(() => {
+    mkdirSync(REPORT_DIR, { recursive: true });
+    const report = {
+      generated_at: new Date().toISOString(),
+      update_mode: UPDATE_BASELINE,
+      archetypes: baseline.archetypes,
+      results,
+      unregistered_routes: results
+        .filter((r) => r.registered_archetype === null)
+        .map((r) => r.route),
+      drift_routes: results
+        .filter((r) => r.drift_archetype !== null)
+        .map((r) => ({
+          route: r.route,
+          registered_as: r.registered_archetype,
+          matches_archetype: r.drift_archetype,
+        })),
+    };
+    writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+
+    if (UPDATE_BASELINE) {
+      // Refresh committed archetype hashes with the values captured from
+      // this run. Leaves route_assignments alone; new archetypes / routes
+      // remain a deliberate authorship step.
+      const updated: Baseline = {
+        archetypes: { ...baseline.archetypes },
+        route_assignments: { ...baseline.route_assignments },
+      };
+      for (const result of results) {
+        const archetypeName = result.registered_archetype;
+        if (archetypeName && archetypeName in updated.archetypes) {
+          updated.archetypes[archetypeName] = {
+            ...updated.archetypes[archetypeName],
+            skeleton_hash: result.actual_hash,
+          };
+        }
+      }
+      writeFileSync(BASELINE_PATH, `${JSON.stringify(updated, null, 2)}\n`);
+    }
+  });
+
+  for (const route of allRoutes) {
+    test(`${route} — DOM skeleton matches registered archetype`, async ({
+      page,
+    }) => {
+      const inSitemap = sitemapRouteSet.has(route);
+      const isRegistered = registeredRouteSet.has(route);
+      const source: RouteSource =
+        inSitemap && isRegistered
+          ? 'both'
+          : inSitemap
+            ? 'sitemap'
+            : 'registered';
+
+      await page.goto(route, { waitUntil: 'networkidle' });
+
+      const skeleton = (await page.evaluate(() => {
+        function extract(el: Element): {
+          tag: string;
+          classes: string[];
+          children: unknown[];
+        } {
+          const children: unknown[] = [];
+          for (const child of Array.from(el.children)) {
+            children.push(extract(child));
+          }
+          const classes = Array.from(el.classList)
+            .map((c) => c.toLowerCase())
+            .sort();
+          // Fixed key order (tag, classes, children) matches the host-side
+          // SkeletonNode shape; JSON.stringify preserves insertion order,
+          // making the hash deterministic.
+          return {
+            tag: el.tagName.toLowerCase(),
+            classes,
+            children,
+          };
+        }
+        const main = document.querySelector('main');
+        if (!main) {
+          throw new Error(
+            `No <main> element on ${window.location.pathname} — ` +
+              `cannot extract skeleton (expected by BaseLayout).`,
+          );
+        }
+        return extract(main);
+      })) as SkeletonNode;
+
+      const hash = hashSkeleton(skeleton);
+
+      const registeredArchetype = baseline.route_assignments[route] ?? null;
+      const expectedHash =
+        registeredArchetype !== null
+          ? (baseline.archetypes[registeredArchetype]?.skeleton_hash ?? null)
+          : null;
+      const matches = registeredArchetype !== null && hash === expectedHash;
+      const driftArchetype = matches
+        ? null
+        : findMatchingArchetype(hash, baseline.archetypes, registeredArchetype);
+
+      results.push({
+        route,
+        source,
+        registered_archetype: registeredArchetype,
+        actual_hash: hash,
+        expected_hash: expectedHash,
+        matches,
+        drift_archetype: driftArchetype,
+      });
+
+      // Baseline-update mode: skip assertions so the reporter captures every
+      // current hash. New routes still need a manual authorship step to land
+      // in `route_assignments`, which keeps the archetype-registration
+      // decision explicit (see audit-tooling-design § 2.1).
+      if (UPDATE_BASELINE) return;
+
+      // Failure mode (a): route has no registered archetype.
+      if (registeredArchetype === null) {
+        const lines = [
+          `Unregistered route: ${route} (source: ${source})`,
+          `  actual skeleton_hash: ${hash}`,
+        ];
+        if (driftArchetype) {
+          lines.push(
+            `  hash matches existing archetype "${driftArchetype}" — add ` +
+              `{ "${route}": "${driftArchetype}" } to route_assignments in ` +
+              `tests/audit/__baselines__/route-clusters.json.`,
+          );
+        } else {
+          lines.push(
+            `  hash matches NO existing archetype. Either:`,
+            `    (i) register ${route} under a new archetype in ` +
+              `tests/audit/__baselines__/route-clusters.json and rerun ` +
+              `UPDATE_BASELINE=1, or`,
+            `    (ii) bring the route's structure in line with an existing ` +
+              `archetype.`,
+          );
+        }
+        throw new Error(lines.join('\n'));
+      }
+
+      // Failure mode (b): registered archetype differs from matching archetype
+      // (category drift).
+      if (driftArchetype !== null) {
+        throw new Error(
+          [
+            `Category drift: ${route} is registered as "${registeredArchetype}" ` +
+              `but its skeleton hash matches archetype "${driftArchetype}".`,
+            `  actual skeleton_hash: ${hash}`,
+            `  If this drift is intentional, update route_assignments to ` +
+              `"${driftArchetype}". Otherwise, a recent change converged two ` +
+              `archetypes — revisit the structural difference.`,
+          ].join('\n'),
+        );
+      }
+
+      // Standard hash mismatch — same archetype, but its structure shifted.
+      if (!matches) {
+        throw new Error(
+          [
+            `Skeleton mismatch for ${route} (archetype "${registeredArchetype}").`,
+            `  expected skeleton_hash: ${expectedHash}`,
+            `  actual   skeleton_hash: ${hash}`,
+            `  If the structural change is intentional, regenerate the ` +
+              `baseline in Docker:`,
+            `    docker run --rm -v "$(pwd)":/work -w /work -e CI=true \\`,
+            `      mcr.microsoft.com/playwright:v1.59.1-noble \\`,
+            `      sh -c "npm ci && UPDATE_BASELINE=1 npm run test:audit:routes"`,
+            `  and commit the updated tests/audit/__baselines__/route-clusters.json.`,
+          ].join('\n'),
+        );
+      }
+    });
+  }
+});

--- a/tests/audit/routes.spec.ts
+++ b/tests/audit/routes.spec.ts
@@ -44,8 +44,11 @@ const REPORT_DIR = join(TESTS_DIR, '__reports__');
 const REPORT_PATH = join(REPORT_DIR, 'routes-report.json');
 
 // UPDATE_BASELINE=1 refreshes committed archetype hashes from the current
-// build. In-flight (never-registered) routes still fail to keep the
-// human-in-the-loop archetype-registration step explicit.
+// build (only for routes that match an archetype's canonical_path — see
+// afterAll). Unregistered routes still fail even in update mode to keep
+// the human-in-the-loop archetype-registration step explicit; hash-only
+// drift within registered routes is absorbed silently, which is the
+// point of running update.
 const UPDATE_BASELINE = process.env.UPDATE_BASELINE === '1';
 
 interface Archetype {
@@ -193,10 +196,36 @@ test.describe('QA-10.1 Route Clustering', () => {
 
   test.afterAll(() => {
     mkdirSync(REPORT_DIR, { recursive: true });
+
+    // Compute the post-update archetype set first so both the written baseline
+    // (in update mode) and the report's `archetypes` field agree. In normal
+    // mode, updatedArchetypes equals baseline.archetypes (no-op copy).
+    // Refresh ONLY from each archetype's canonical_path route: if two routes
+    // share an archetype (which is allowed — route_assignments is a map),
+    // naive iteration would let the last result in order silently bless a
+    // drifted/mismatching route. canonical_path is the single authoritative
+    // source per archetype.
+    const updatedArchetypes: Record<string, Archetype> = {
+      ...baseline.archetypes,
+    };
+    if (UPDATE_BASELINE) {
+      for (const result of results) {
+        const archetypeName = result.registered_archetype;
+        if (!archetypeName) continue;
+        const archetype = updatedArchetypes[archetypeName];
+        if (!archetype) continue;
+        if (result.route !== archetype.canonical_path) continue;
+        updatedArchetypes[archetypeName] = {
+          ...archetype,
+          skeleton_hash: result.actual_hash,
+        };
+      }
+    }
+
     const report = {
       generated_at: new Date().toISOString(),
       update_mode: UPDATE_BASELINE,
-      archetypes: baseline.archetypes,
+      archetypes: updatedArchetypes,
       results,
       unregistered_routes: results
         .filter((r) => r.registered_archetype === null)
@@ -212,23 +241,14 @@ test.describe('QA-10.1 Route Clustering', () => {
     writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
 
     if (UPDATE_BASELINE) {
-      // Refresh committed archetype hashes with the values captured from
-      // this run. Leaves route_assignments alone; new archetypes / routes
-      // remain a deliberate authorship step.
-      const updated: Baseline = {
-        archetypes: { ...baseline.archetypes },
+      const updatedBaseline: Baseline = {
+        archetypes: updatedArchetypes,
         route_assignments: { ...baseline.route_assignments },
       };
-      for (const result of results) {
-        const archetypeName = result.registered_archetype;
-        if (archetypeName && archetypeName in updated.archetypes) {
-          updated.archetypes[archetypeName] = {
-            ...updated.archetypes[archetypeName],
-            skeleton_hash: result.actual_hash,
-          };
-        }
-      }
-      writeFileSync(BASELINE_PATH, `${JSON.stringify(updated, null, 2)}\n`);
+      writeFileSync(
+        BASELINE_PATH,
+        `${JSON.stringify(updatedBaseline, null, 2)}\n`,
+      );
     }
   });
 
@@ -282,6 +302,19 @@ test.describe('QA-10.1 Route Clustering', () => {
       const hash = hashSkeleton(skeleton);
 
       const registeredArchetype = baseline.route_assignments[route] ?? null;
+      // Catch route_assignments that name a non-existent archetype early.
+      // Otherwise the downstream "Skeleton mismatch" error reports
+      // `expected: null` which is hard to diagnose.
+      if (
+        registeredArchetype !== null &&
+        !(registeredArchetype in baseline.archetypes)
+      ) {
+        throw new Error(
+          `Unknown archetype in route_assignments: "${registeredArchetype}" ` +
+            `(route: ${route}). Either add an archetype with that name to ` +
+            `baseline.archetypes, or correct the route_assignments entry.`,
+        );
+      }
       const expectedHash =
         registeredArchetype !== null
           ? (baseline.archetypes[registeredArchetype]?.skeleton_hash ?? null)
@@ -301,13 +334,12 @@ test.describe('QA-10.1 Route Clustering', () => {
         drift_archetype: driftArchetype,
       });
 
-      // Baseline-update mode: skip assertions so the reporter captures every
-      // current hash. New routes still need a manual authorship step to land
-      // in `route_assignments`, which keeps the archetype-registration
-      // decision explicit (see audit-tooling-design § 2.1).
-      if (UPDATE_BASELINE) return;
-
       // Failure mode (a): route has no registered archetype.
+      // Runs BEFORE the UPDATE_BASELINE early-return: baseline regeneration
+      // must never silently absorb a new route — archetype assignment is a
+      // human authorship step (see audit-tooling-design § 2.1). Hash-only
+      // drift on already-registered routes IS absorbed in update mode; that
+      // is what "update" means.
       if (registeredArchetype === null) {
         const lines = [
           `Unregistered route: ${route} (source: ${source})`,
@@ -331,6 +363,11 @@ test.describe('QA-10.1 Route Clustering', () => {
         }
         throw new Error(lines.join('\n'));
       }
+
+      // Baseline-update mode: skip the hash-match assertions so the reporter
+      // captures every current hash and afterAll writes them back into the
+      // baseline. Unregistered-route detection above remains in force.
+      if (UPDATE_BASELINE) return;
 
       // Failure mode (b): registered archetype differs from matching archetype
       // (category drift).


### PR DESCRIPTION
## Summary

PDR-007 Phase 1 audit component: Playwright spec that walks the built sitemap + explicitly-registered routes, extracts the canonical DOM skeleton inside `<main>`, SHA-256 hashes it, and fails when a route's hash does not match its registered archetype (or no archetype is registered). Exact-match skeleton hashing — explicitly not similarity-based clustering per PDR-007 Risk 2.

Closes #120.

## Changes

| File | Change |
|---|---|
| `tests/audit/routes.spec.ts` (new) | Sitemap walker + DOM skeleton extractor + SHA-256 hasher + per-route assertion. Fixed key order (`tag, classes, children`) + `JSON.stringify` for deterministic canonical form. Serial-mode describe with shared `results` → `afterAll` report write. `UPDATE_BASELINE=1` refreshes committed archetype hashes. |
| `tests/audit/__baselines__/route-clusters.json` (new) | 5 archetypes (`home`, `blog-index`, `blog-post`, `about`, `error`) + `route_assignments` for all 5 routes. Hashes regenerated inside `mcr.microsoft.com/playwright:v1.59.1-noble` per the Linux-Docker discipline rule. |
| `playwright.config.ts` | Register new `audit-routes` project (chromium, Desktop Chrome device, `testMatch: /audit\/routes\.spec\.ts$/`). |
| `package.json` | Add `test:audit:routes` + `test:audit:routes:update` scripts. |
| `.github/workflows/ci.yml` | Rename Playwright step to include QA-10.1. The single `npx playwright test` invocation picks up the new project automatically via `testMatch` routing — no new job. |
| `.gitignore` | Ignore `tests/audit/__reports__/` (per-run output; the committed baseline under `__baselines__/` stays tracked). |

## Archetype decisions for `/about/` and `/404.html`

Resolved at the 2026-04-21 refinement (documented in issue #120 body): **both become new archetypes, not absorbed into `home`.**

| Route | Distinguishing structure | Archetype |
|---|---|---|
| `/about/` (`src/pages/about.astro`) | `<article class="about">` with long-form editorial `<header class="about-header">` + `<div class="prose">` chrome — no hero / featured / grid / filter / post-metadata | **new: `about`** |
| `/404.html` (`src/pages/404.astro`) | `<section class="not-found">` with four flat children (`p.not-found-code`, `h1`, `p.not-found-message`, `a.not-found-link`) and a distinct bordered-pill CTA | **new: `error`** |

Forcing either into `home` would require (a) dropping the `<article>` vs `<section class="hero/featured/recent">` distinction during normalization (degrades future-drift signal) or (b) accepting a permanent hash mismatch. New archetypes are the design-correct call.

`error` is chosen over `404` to remain forward-compatible if other error surfaces (410, 5xx) are added later — `404` as an archetype name would prematurely bind the category to one HTTP status.

## Failure modes (proven in Docker)

**Mode (a) — unregistered route** (hash has no matching archetype AND route not in `route_assignments`):

```
Error: Unregistered route: /about/ (source: sitemap)
  actual skeleton_hash: 822e794ba73d0a5ce32972a864cf0e0509e109b4ce2e83c25754347d32c4ab5f
  hash matches existing archetype "about" — add { "/about/": "about" } to route_assignments in tests/audit/__baselines__/route-clusters.json.
```

*(Reproduced by removing `/about/` from `route_assignments` and running `npm run test:audit:routes` in Docker.)*

**Mode (b) — skeleton mismatch** (registered route, but its DOM structure diverged from the archetype):

```
Error: Skeleton mismatch for /about/ (archetype "about").
  expected skeleton_hash: 822e794ba73d0a5ce32972a864cf0e0509e109b4ce2e83c25754347d32c4ab5f
  actual   skeleton_hash: 5c97c2c45a51687541d26a0eb25515f13865a577c77a90e1b29327e8f3eca5c1
  If the structural change is intentional, regenerate the baseline in Docker:
    docker run --rm -v "$(pwd)":/work -w /work -e CI=true \
      mcr.microsoft.com/playwright:v1.59.1-noble \
      sh -c "npm ci && UPDATE_BASELINE=1 npm run test:audit:routes"
```

*(Reproduced by adding `reverse-test-mutation` class to `<article class="about">` in `src/pages/about.astro` and running `npm run test:audit:routes` in Docker.)*

Both failure modes name the route clearly in the test title AND the error message, and both include actionable remediation.

## Design notes

**Route iteration is UNION of sitemap + `route_assignments` keys.** Sitemap-only catches new pages (fail as unregistered); registered-only catches `/404.html` (correctly excluded from sitemap because error pages shouldn't be indexed).

**DOM skeleton scope is `<main>`.** `BaseLayout` wraps every page in `<main id="main-content">`, and all archetype-distinguishing structure (hero/featured/recent vs blog-index vs post chrome vs article-prose vs four-child error) lives inside that wrapper. Scoping to `<main>` excludes the shared `<header>/<nav>` and `<footer>` chrome from the hash.

**Emit shape `{ tag, classes (sorted, lowercase), children[] }`.** Strips text nodes, all attribute values except class tokens, and all non-class attributes including `data-astro-cid-*` and `data-*`/`aria-*` values. `<!-- Astro comments -->` are skipped because `el.children` returns only ELEMENT children. Class sorting + lowercasing is deterministic.

**Hash determinism.** `JSON.stringify` preserves object-key insertion order in V8; the extractor builds every node with fixed key order (`tag, classes, children`), so no custom canonicalizer is needed. macOS and Linux Docker produced identical hashes in side-by-side testing — as expected since the walker operates on DOM structure, not rendering. The Docker-regenerated baseline is committed per the repo's discipline rule even though determinism is high in principle.

**Serial mode.** `test.describe.configure({ mode: 'serial' })` keeps all five routes in one worker, which lets the `results` array accumulate consistently for the `afterAll` report write. The audit is fast (≈5s end-to-end) and parallelization here would trade report integrity for ~1s of saved wall-clock.

**Regex-based sitemap parsing.** `@astrojs/sitemap` emits stable, unescaped URLs inside flat `<loc>` tags; `content.matchAll(/<loc>([^<]+)<\/loc>/g)` is enough and avoids pulling in an XML parser for a trivial extraction. Matches the vanilla-Node discipline of `scripts/check-playwright-version-parity.mjs`.

## Test plan

- [x] `npm run test:audit:routes` passes locally (5/5) against the committed baseline.
- [x] Baseline regenerated inside Playwright Linux Docker (`mcr.microsoft.com/playwright:v1.59.1-noble`) — hashes are Linux-canonical.
- [x] Reverse test (mode a) — removing a route from `route_assignments` fails with "Unregistered route" and names the route.
- [x] Reverse test (mode b) — mutating a page's DOM structure fails with "Skeleton mismatch" and names the route with both hashes.
- [x] Per-run report written to `tests/audit/__reports__/routes-report.json` with per-route actual/expected hashes, drift detection, and unregistered-route list.
- [x] `npm run lint`, `npm run typecheck`, `npm run test` (vitest), `npm run check:playwright-version-parity` all clean.
- [x] `npx prettier --check` clean on all files touched by this PR.
- [ ] CI green on push (QA-06/07/08/09/QA-10.1 Playwright + Lighthouse).

## References

- PDR-007 § Decision Phase 1 (HQ repo, private — see [CONTRIBUTING § Cross-repo setup](../blob/main/CONTRIBUTING.md#cross-repo-setup))
- `audit-tooling-design.md` § 2.1, § 3, § 5 Risk 2 (HQ repo, private)
- Existing patterns: `tests/visual/screenshots.spec.ts`, `playwright.config.ts`
- Phase 1 gate tracking: #125 (`tests/audit/PHASE-GATES.md`)
- Route-archetype runbook (separate): #124 (`tests/audit/ROUTE-CLUSTERS-RUNBOOK.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)