### PR TITLE
(feat) add QA-10.3 invariant specs MVP per PDR-007 Phase 1 (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
 
       # Playwright-driven gates: QA-09 visual regression +
       # QA-08 axe-core WCAG 2.2 AA + QA-07 touch-target audit +
-      # QA-10.1 route clustering (PDR-007 Phase 1 audit tooling).
-      # A single `playwright test` invocation covers all four
-      # suites because projects in playwright.config.ts use
-      # testMatch to route specs to the right project(s).
+      # QA-10.1 route clustering + QA-10.3 invariant specs (PDR-007
+      # Phase 1 audit tooling). A single `playwright test` invocation
+      # covers every suite because projects in playwright.config.ts
+      # use testMatch to route specs to the right project(s).
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
@@ -70,7 +70,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
-      - name: QA-07 / QA-08 / QA-09 / QA-10.1 — Playwright suites
+      - name: QA-07 / QA-08 / QA-09 / QA-10.1 / QA-10.3 — Playwright suites
         run: npx playwright test
 
       - name: Upload Playwright HTML report

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:touch-targets": "npm run build && playwright test tests/a11y/touch-targets.spec.ts",
     "test:audit:routes": "npm run build && playwright test --project=audit-routes",
     "test:audit:routes:update": "npm run build && UPDATE_BASELINE=1 playwright test --project=audit-routes",
+    "test:audit:invariants": "npm run build && playwright test --project=audit-invariants",
     "test:lighthouse": "npm run build && lhci autorun",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Unified Playwright configuration for QA-07 / QA-08 / QA-09 / QA-10.1.
+ * Unified Playwright configuration for QA-07 / QA-08 / QA-09 / QA-10.1 / QA-10.3.
  *
  * Four test suites share this config and one `astro preview` webServer:
  *   - `tests/visual/**`        — QA-09 visual regression baselines.
@@ -13,11 +13,16 @@ import { defineConfig, devices } from '@playwright/test';
  *                                sitemap walk + DOM skeleton hash (per
  *                                PDR-007 Phase 1; shares the Desktop Chrome
  *                                device with the visual suite).
+ *   - `tests/audit/invariants.spec.ts` + `invariants.reverse.spec.ts` —
+ *                                QA-10.3 boolean layout invariants
+ *                                (iterate viewports in-spec; one project).
  *
  * Visual + axe + audit-routes run in chromium projects (Desktop Chrome
  * device metrics); touch-targets runs once per mobile viewport because
  * its spec reads the viewport from the project, not from in-spec
- * iteration.
+ * iteration. audit-invariants runs serially in a single worker so the
+ * per-run JSON report (tests/audit/__reports__/invariants-report.json)
+ * aggregates cleanly across the flat test list.
  *
  * Per `tests/visual/README.md`: snapshotPathTemplate keeps baselines at
  * `tests/visual/__baselines__/` regardless of the new `./tests` testDir.
@@ -73,6 +78,18 @@ export default defineConfig({
         hasTouch: true,
       },
     })),
+    // QA-10.3: invariants iterate viewports + modes in-spec, so the
+    // project itself carries no viewport. fullyParallel: false + single
+    // test file with `test.describe.configure({ mode: 'serial' })` keep
+    // report emission deterministic across workers.
+    {
+      name: 'audit-invariants',
+      testMatch: /audit\/invariants(\.reverse)?\.spec\.ts$/,
+      fullyParallel: false,
+      use: {
+        browserName: 'chromium' as const,
+      },
+    },
   ],
 
   // `astro preview` serves the `dist/` build output — caller must run

--- a/tests/audit/helpers.ts
+++ b/tests/audit/helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared browser-side helpers for QA-10.3 invariant specs.
+ *
+ * The Invariant 1 predicate lives HERE so the forward spec
+ * (invariants.spec.ts) and the reverse spec (invariants.reverse.spec.ts) run
+ * the exact same code. If they drifted, the reverse spec would vouch for a
+ * predicate that isn't the one actually gating CI — the reverse test's
+ * evidentiary value depends on this identity.
+ *
+ * The functions exported here are passed to `page.evaluate`, which
+ * serializes them via `toString()` and executes in the browser. They must
+ * therefore be SELF-CONTAINED — no closures, no imports, only references
+ * resolvable in the browser global scope (document, getComputedStyle, etc.).
+ */
+
+export type Invariant1Measurement =
+  | { pass: false; error: string }
+  | {
+      pass: boolean;
+      markWeight: number;
+      comparedCount: number;
+      violations: Array<{ selector: string; weight: number; text: string }>;
+    };
+
+export const invariant1Predicate = ({
+  navSel,
+  markSel,
+}: {
+  navSel: string;
+  markSel: string;
+}): Invariant1Measurement => {
+  function describeElement(el: Element): string {
+    const tag = el.tagName.toLowerCase();
+    const raw = typeof el.className === 'string' ? el.className.trim() : '';
+    const cls = raw ? '.' + raw.split(/\s+/).join('.') : '';
+    return `${tag}${cls}`;
+  }
+  const nav = document.querySelector(navSel);
+  if (!nav) return { pass: false, error: `nav not found: ${navSel}` };
+  const mark = nav.querySelector(markSel);
+  if (!mark) return { pass: false, error: `wordmark not found: ${markSel}` };
+  const markWeight = Number(getComputedStyle(mark).fontWeight);
+  const others = Array.from(nav.querySelectorAll('*')).filter(
+    (el) => !!el.textContent?.trim() && !mark.contains(el),
+  );
+  const violations = others
+    .map((el) => ({
+      selector: describeElement(el),
+      weight: Number(getComputedStyle(el).fontWeight),
+      text: (el.textContent ?? '').trim().slice(0, 48),
+    }))
+    .filter((row) => row.weight > markWeight);
+  return {
+    pass: violations.length === 0,
+    markWeight,
+    comparedCount: others.length,
+    violations,
+  };
+};

--- a/tests/audit/invariants.reverse.spec.ts
+++ b/tests/audit/invariants.reverse.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * QA-10.3 reverse-test evidence — Invariant 1 detection proof.
+ *
+ * Issue #121 AC: "at least one invariant, when a fixture is deliberately
+ * broken (e.g., temporary CSS change makes wordmark `font-weight: 400`),
+ * fails with a measurement-rich message identifying the violation."
+ *
+ * This spec injects a CSS rule that makes .wordmark-text's font-weight fall
+ * below a `.pillar-link` (and below any other nav text-bearing node) and
+ * then runs the Invariant 1 predicate against the broken DOM. The test
+ * PASSES when the predicate CORRECTLY DETECTS the violation and surfaces
+ * concrete measurements (weights, selectors, text previews).
+ *
+ * Runs in the same `audit-invariants` Playwright project as the primary
+ * spec, so it is exercised on every CI run — the existence of live
+ * detection is a standing guarantee rather than a one-off demo.
+ */
+import { test, expect, type Browser } from '@playwright/test';
+
+import { invariant1Predicate } from './helpers';
+import { SELECTORS } from './selectors';
+
+async function openHomeWithInjection(
+  browser: Browser,
+  css: string,
+): Promise<{
+  page: import('@playwright/test').Page;
+  close: () => Promise<void>;
+}> {
+  const context = await browser.newContext({
+    viewport: { width: 480, height: 900 },
+    colorScheme: 'light',
+    reducedMotion: 'reduce',
+  });
+  await context.addInitScript(() => {
+    window.localStorage.setItem('theme', 'light');
+  });
+  const page = await context.newPage();
+  await page.goto('/', { waitUntil: 'networkidle' });
+  // Inject AFTER load so the override wins the cascade.
+  await page.addStyleTag({ content: css });
+  return {
+    page,
+    close: async () => {
+      await context.close();
+    },
+  };
+}
+
+test('reverse: Invariant 1 detects a forced-normal wordmark with rich measurements', async ({
+  browser,
+}) => {
+  // Inversion: force .wordmark-text to normal weight AND a pillar-link to
+  // bold. Under the intact design both are Medium/Semibold or lower vs.
+  // Bold 700 mark — inverting produces a concrete, targeted violation.
+  const breakingCss = `
+    .wordmark-text { font-weight: 400 !important; }
+    .pillar-link { font-weight: 800 !important; }
+  `;
+  const { page, close } = await openHomeWithInjection(browser, breakingCss);
+
+  try {
+    const measurement = await page.evaluate(invariant1Predicate, {
+      navSel: SELECTORS.siteNav,
+      markSel: SELECTORS.wordmarkText,
+    });
+
+    // The injected CSS is a real violation — the predicate must detect it.
+    expect(
+      measurement.pass,
+      `Invariant 1 FAILED to detect the injected violation. Raw measurement: ${JSON.stringify(
+        measurement,
+        null,
+        2,
+      )}`,
+    ).toBe(false);
+
+    // Narrow to the success-shape (pass:false + error) vs the measurement
+    // shape. Error branch means the predicate didn't even reach the scan —
+    // that's an infrastructure failure, not detection evidence.
+    if ('error' in measurement) {
+      throw new Error(
+        `predicate short-circuited before scanning: ${measurement.error}`,
+      );
+    }
+
+    // Measurement richness: the detection must expose the concrete
+    // wordmark weight, the count of compared nodes, and the specific
+    // violating entries with selector / weight / text-preview.
+    expect(measurement.markWeight, 'markWeight must be reported').toBe(400);
+    expect(
+      typeof measurement.comparedCount,
+      'comparedCount must be a number',
+    ).toBe('number');
+    expect(
+      Array.isArray(measurement.violations),
+      'violations must be an array',
+    ).toBe(true);
+    expect(
+      measurement.violations.length,
+      'at least one violating element is expected',
+    ).toBeGreaterThan(0);
+
+    // The pillar-link is the element whose weight was forced up. Its
+    // presence in the violation list — with its pumped-up weight — is
+    // the concrete, actionable signal we want from a live failure.
+    const pillarHit = measurement.violations.find((v) =>
+      v.selector.startsWith('a.pillar-link'),
+    );
+    expect(
+      pillarHit,
+      `expected .pillar-link to appear in violations; got ${JSON.stringify(
+        measurement.violations,
+      )}`,
+    ).toBeDefined();
+    expect(pillarHit!.weight, 'pillar-link weight reported').toBe(800);
+    expect(
+      pillarHit!.text.length,
+      'pillar-link text preview reported',
+    ).toBeGreaterThan(0);
+  } finally {
+    await close();
+  }
+});

--- a/tests/audit/invariants.spec.ts
+++ b/tests/audit/invariants.spec.ts
@@ -1,0 +1,511 @@
+/**
+ * QA-10.3 Invariant Specs MVP — 5 home-page layout invariants.
+ *
+ * Source of truth: PDR-007 § Decision Phase 1; audit-tooling-design.md § 2.3.
+ * Issue: how-do-i-ai/how-do-i-ai.github.io#121.
+ *
+ * Invariants encode design intent as boolean geometric/CSSOM predicates that
+ * either hold or do not. They are NOT pixel-exact measurements — per design
+ * doc § 2.3, sub-pixel font-metric drift between macOS and Linux must be
+ * absorbed by the predicate shape. The precipitating failure (PR #99 B1
+ * overlap regression) motivates Invariant 4 specifically.
+ *
+ * Report contract: a per-run JSON summary is emitted to
+ * `tests/audit/__reports__/invariants-report.json` (gitignored) containing
+ * per-invariant, per-viewport measurements so CI artifacts can surface
+ * WHY a gate fired, not just THAT it fired.
+ */
+import {
+  test,
+  expect,
+  type Browser,
+  type BrowserContext,
+} from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { invariant1Predicate } from './helpers';
+import { SELECTORS } from './selectors';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const REPORT_PATH = resolve(here, '__reports__', 'invariants-report.json');
+
+// Serial mode: tests accumulate results in the module-scoped `results`
+// array and afterAll flushes to disk. Parallel workers would fragment the
+// report; the project-level fullyParallel: false (in playwright.config.ts)
+// is the belt-and-suspenders counterpart.
+test.describe.configure({ mode: 'serial' });
+
+type Mode = 'light' | 'dark';
+
+type RunResult = {
+  viewport: string;
+  mode: Mode;
+  pass: boolean;
+  measurements: { pass: boolean; [key: string]: unknown };
+};
+
+type InvariantResult = {
+  id: string;
+  title: string;
+  pass: boolean;
+  runs: RunResult[];
+};
+
+const results: InvariantResult[] = [];
+
+test.afterAll(() => {
+  mkdirSync(dirname(REPORT_PATH), { recursive: true });
+  const payload = {
+    schema: 'qa-10.3/invariants-report/v1',
+    timestamp: new Date().toISOString(),
+    invariants: results,
+  };
+  writeFileSync(REPORT_PATH, JSON.stringify(payload, null, 2) + '\n');
+});
+
+async function openHome(
+  browser: Browser,
+  opts: { width: number; height?: number; mode?: Mode },
+): Promise<{ context: BrowserContext; page: import('@playwright/test').Page }> {
+  const mode: Mode = opts.mode ?? 'light';
+  const height = opts.height ?? 900;
+
+  const context = await browser.newContext({
+    viewport: { width: opts.width, height },
+    colorScheme: mode,
+    reducedMotion: 'reduce',
+  });
+
+  // Pin theme deterministically: BaseHead.astro's inline script reads
+  // localStorage.theme pre-paint. Belt-and-suspenders with colorScheme.
+  await context.addInitScript((m) => {
+    window.localStorage.setItem('theme', m);
+  }, mode);
+
+  const page = await context.newPage();
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  // Sanity check the theme actually applied before we measure.
+  if (mode === 'dark') {
+    await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+  } else {
+    await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
+  }
+
+  return { context, page };
+}
+
+function assertAllRunsPassed(summary: string, runs: RunResult[]): void {
+  const fails = runs.filter((r) => !r.pass);
+  if (fails.length === 0) return;
+  const lines = fails.map(
+    (f) =>
+      `  - ${f.viewport}px (${f.mode}): ${JSON.stringify(
+        f.measurements,
+        null,
+        2,
+      )
+        .split('\n')
+        .join('\n    ')}`,
+  );
+  throw new Error(`${summary}\n${lines.join('\n')}`);
+}
+
+/* ---------------------------------------------------------------------------
+ * Invariant 1 — Wordmark is the strongest type in .site-nav.
+ *
+ * REQ-NAV-02 GWT: "wordmark remains the strongest type in the nav."
+ * Nav.astro:207 anchor comment: "Medium 500 base; wordmark stays strongest
+ * at 700." Brand-hierarchy guard.
+ *
+ * Predicate: for every text-bearing descendant of .site-nav outside
+ * .wordmark-text's subtree, computed font-weight ≤ computed font-weight of
+ * .wordmark-text. Font-weight is color-scheme-independent; light is enough.
+ * ------------------------------------------------------------------------- */
+test('Invariant 1: wordmark is the strongest type in the site nav', async ({
+  browser,
+}) => {
+  const viewports = [320, 375, 480, 768, 1024];
+  const runs: RunResult[] = [];
+
+  for (const width of viewports) {
+    const { context, page } = await openHome(browser, { width });
+    try {
+      const measurement = await page.evaluate(invariant1Predicate, {
+        navSel: SELECTORS.siteNav,
+        markSel: SELECTORS.wordmarkText,
+      });
+      runs.push({
+        viewport: String(width),
+        mode: 'light',
+        pass: measurement.pass,
+        measurements: measurement,
+      });
+    } finally {
+      await context.close();
+    }
+  }
+
+  results.push({
+    id: 'invariant-1',
+    title: 'Wordmark is the strongest type in .site-nav',
+    pass: runs.every((r) => r.pass),
+    runs,
+  });
+  assertAllRunsPassed(
+    'Invariant 1 violated — at least one .site-nav text node renders heavier than .wordmark-text:',
+    runs,
+  );
+});
+
+/* ---------------------------------------------------------------------------
+ * Invariant 2 — --color-accent resolves to a non-empty color value.
+ *
+ * REQ-HOME-01 GWT: "accent coloring is non-negotiable at every breakpoint."
+ * PDR-004: accent swap #E85D2A (light) → #F06937 (dark) must survive to 320.
+ * tokens.css:15 (light), tokens.css:118 (dark).
+ *
+ * Predicate: getPropertyValue('--color-accent') returns a non-empty string
+ * matching #hex or rgb()/rgba(). Light + dark are both required.
+ * ------------------------------------------------------------------------- */
+test('Invariant 2: --color-accent resolves at every viewport in both modes', async ({
+  browser,
+}) => {
+  const viewports = [320, 768, 1440];
+  const modes: Mode[] = ['light', 'dark'];
+  const runs: RunResult[] = [];
+
+  for (const width of viewports) {
+    for (const mode of modes) {
+      const { context, page } = await openHome(browser, { width, mode });
+      try {
+        const measurement = await page.evaluate(() => {
+          const value = getComputedStyle(document.documentElement)
+            .getPropertyValue('--color-accent')
+            .trim();
+          const isHex = /^#[0-9a-f]{3,8}$/i.test(value);
+          const isRgb = /^rgba?\(/i.test(value);
+          return {
+            pass: value !== '' && (isHex || isRgb),
+            value,
+            format: isHex ? 'hex' : isRgb ? 'rgb' : 'unknown',
+          };
+        });
+        runs.push({
+          viewport: String(width),
+          mode,
+          pass: measurement.pass,
+          measurements: measurement,
+        });
+      } finally {
+        await context.close();
+      }
+    }
+  }
+
+  results.push({
+    id: 'invariant-2',
+    title: '--color-accent resolves to a non-empty color value',
+    pass: runs.every((r) => r.pass),
+    runs,
+  });
+  assertAllRunsPassed(
+    'Invariant 2 violated — --color-accent is empty or not a recognized color format:',
+    runs,
+  );
+});
+
+/* ---------------------------------------------------------------------------
+ * Invariant 3 — .hero-tagline never orphans an accent word on the first or
+ *               last visual line.
+ *
+ * PDR-004 § Wrap behavior (2026-04-19 amendment): "no accent word may stand
+ * alone on the first or last line of its phrase." REQ-HOME-01 GWT: "no
+ * accent word orphans on the first or last line." The text-wrap: balance
+ * CSS is the mechanism; this invariant asserts the OUTCOME.
+ *
+ * Predicate: after grouping Range.getClientRects() from each top-level
+ * child of .hero-tagline into visual lines by top coordinate (1px tolerance
+ * for sub-pixel drift), the first line AND the last line each contain at
+ * least one rect from a NON-accent source.
+ * ------------------------------------------------------------------------- */
+test('Invariant 3: .hero-tagline first/last line each contains non-accent text', async ({
+  browser,
+}) => {
+  const viewports = [320, 360, 375, 414];
+  const runs: RunResult[] = [];
+
+  for (const width of viewports) {
+    const { context, page } = await openHome(browser, { width });
+    try {
+      const measurement = await page.evaluate(
+        ({ taglineSel }) => {
+          const tagline = document.querySelector(taglineSel);
+          if (!tagline)
+            return { pass: false, error: `tagline not found: ${taglineSel}` };
+
+          type RectRecord = {
+            top: number;
+            left: number;
+            right: number;
+            bottom: number;
+            isAccent: boolean;
+            text: string;
+          };
+
+          const rectRecords: RectRecord[] = [];
+          tagline.childNodes.forEach((child) => {
+            const range = document.createRange();
+            range.selectNodeContents(child);
+            const rects = range.getClientRects();
+            const isAccent =
+              child.nodeType === Node.ELEMENT_NODE &&
+              (child as Element).classList.contains('accent');
+            const text = (child.textContent ?? '').trim();
+            for (const rect of Array.from(rects)) {
+              // Discard empty/whitespace-only rects that collapse under the
+              // layout engine — they carry no visible line membership.
+              if (rect.width < 0.5 || rect.height < 0.5) continue;
+              rectRecords.push({
+                top: rect.top,
+                left: rect.left,
+                right: rect.right,
+                bottom: rect.bottom,
+                isAccent,
+                text,
+              });
+            }
+          });
+
+          // Group by top coordinate within a 1px tolerance to absorb
+          // sub-pixel font-metric drift. Iterate rectRecords sorted by top
+          // and bucket into lines.
+          const tolerance = 1;
+          const sorted = [...rectRecords].sort((a, b) => a.top - b.top);
+          const lines: { top: number; records: RectRecord[] }[] = [];
+          for (const rec of sorted) {
+            const existing = lines.find(
+              (l) => Math.abs(l.top - rec.top) <= tolerance,
+            );
+            if (existing) existing.records.push(rec);
+            else lines.push({ top: rec.top, records: [rec] });
+          }
+
+          if (lines.length === 0) {
+            return {
+              pass: false,
+              error: 'no rects produced for .hero-tagline',
+            };
+          }
+
+          // The predicate applies uniformly: first line AND last line
+          // each contain at least one non-accent character. On a
+          // single-line layout the first line IS the last line, so
+          // the same check runs once (and would catch a degenerate
+          // "whole tagline is accent text" regression too).
+          const first = lines[0];
+          const last = lines[lines.length - 1];
+          const firstHasNonAccent = first.records.some((r) => !r.isAccent);
+          const lastHasNonAccent = last.records.some((r) => !r.isAccent);
+
+          return {
+            pass: firstHasNonAccent && lastHasNonAccent,
+            lineCount: lines.length,
+            firstLine: {
+              accentOnly: !firstHasNonAccent,
+              records: first.records.map((r) => ({
+                isAccent: r.isAccent,
+                text: r.text,
+              })),
+            },
+            lastLine: {
+              accentOnly: !lastHasNonAccent,
+              records: last.records.map((r) => ({
+                isAccent: r.isAccent,
+                text: r.text,
+              })),
+            },
+          };
+        },
+        { taglineSel: SELECTORS.heroTagline },
+      );
+      runs.push({
+        viewport: String(width),
+        mode: 'light',
+        pass: measurement.pass,
+        measurements: measurement,
+      });
+    } finally {
+      await context.close();
+    }
+  }
+
+  results.push({
+    id: 'invariant-3',
+    title: '.hero-tagline does not orphan an accent word on first/last line',
+    pass: runs.every((r) => r.pass),
+    runs,
+  });
+  assertAllRunsPassed(
+    'Invariant 3 violated — an accent word is the sole content of the first or last visual line:',
+    runs,
+  );
+});
+
+/* ---------------------------------------------------------------------------
+ * Invariant 4 — .pillar-links bounding rect does not intersect .nav-actions
+ *               bounding rect.
+ *
+ * PDR-006 constraint 6 (2026-04-19 amendment). Encodes the PR #99 B1
+ * regression: at 480vp, flex-wrap: nowrap made .pillar-links (~413px
+ * required) overflow its ~316px allocation and overlap .nav-actions,
+ * obscuring the theme-toggle moon icon with the active pillar chip.
+ * Nav.astro:262-267 names this failure mode explicitly.
+ *
+ * Predicate: bounding-box intersection test (AABB). No pixel-exact
+ * distance measurement; collision is boolean.
+ * ------------------------------------------------------------------------- */
+test('Invariant 4: .pillar-links and .nav-actions never overlap in the collapse band', async ({
+  browser,
+}) => {
+  const viewports = [320, 375, 414, 480, 500, 600, 640, 700, 767];
+  const runs: RunResult[] = [];
+
+  for (const width of viewports) {
+    const { context, page } = await openHome(browser, { width });
+    try {
+      const measurement = await page.evaluate(
+        ({ pillarsSel, actionsSel }) => {
+          const pillars = document.querySelector(pillarsSel);
+          const actions = document.querySelector(actionsSel);
+          if (!pillars)
+            return { pass: false, error: `not found: ${pillarsSel}` };
+          if (!actions)
+            return { pass: false, error: `not found: ${actionsSel}` };
+          const p = pillars.getBoundingClientRect();
+          const a = actions.getBoundingClientRect();
+          const overlaps =
+            p.left < a.right &&
+            p.right > a.left &&
+            p.top < a.bottom &&
+            p.bottom > a.top;
+          return {
+            pass: !overlaps,
+            pillarsRect: {
+              left: p.left,
+              right: p.right,
+              top: p.top,
+              bottom: p.bottom,
+              width: p.width,
+              height: p.height,
+            },
+            actionsRect: {
+              left: a.left,
+              right: a.right,
+              top: a.top,
+              bottom: a.bottom,
+              width: a.width,
+              height: a.height,
+            },
+          };
+        },
+        { pillarsSel: SELECTORS.pillarLinks, actionsSel: SELECTORS.navActions },
+      );
+      runs.push({
+        viewport: String(width),
+        mode: 'light',
+        pass: measurement.pass,
+        measurements: measurement,
+      });
+    } finally {
+      await context.close();
+    }
+  }
+
+  results.push({
+    id: 'invariant-4',
+    title: '.pillar-links does not intersect .nav-actions',
+    pass: runs.every((r) => r.pass),
+    runs,
+  });
+  assertAllRunsPassed(
+    'Invariant 4 violated — .pillar-links overlaps .nav-actions (PR #99 B1 regression class):',
+    runs,
+  );
+});
+
+/* ---------------------------------------------------------------------------
+ * Invariant 5 — No descendant of .site-nav has computed position sticky or
+ *               fixed.
+ *
+ * REQ-MOB-04 declares scroll-padding-top as FORWARD-COMPAT infrastructure
+ * for future sticky nav — sticky nav itself is not present at v1 and its
+ * adoption is gated behind a new PDR. WCAG SC 2.4.11 Focus Not Obscured
+ * (Minimum) is exempted at v1 only while no sticky/fixed elements exist;
+ * this invariant enforces that exemption.
+ *
+ * Predicate: every element under .site-nav has getComputedStyle.position
+ * not in {'sticky', 'fixed'}. Viewport-independent in practice; two
+ * spot-checks around --bp-md bracket the breakpoint cheaply.
+ * ------------------------------------------------------------------------- */
+test('Invariant 5: .site-nav subtree has no sticky or fixed descendants', async ({
+  browser,
+}) => {
+  const viewports = [320, 768];
+  const runs: RunResult[] = [];
+
+  for (const width of viewports) {
+    const { context, page } = await openHome(browser, { width });
+    try {
+      const measurement = await page.evaluate(
+        ({ navSel }) => {
+          function describeElement(el: Element): string {
+            const tag = el.tagName.toLowerCase();
+            const raw =
+              typeof el.className === 'string' ? el.className.trim() : '';
+            const cls = raw ? '.' + raw.split(/\s+/).join('.') : '';
+            return `${tag}${cls}`;
+          }
+          const rootMatches = Array.from(
+            document.querySelectorAll(`${navSel}, ${navSel} *`),
+          );
+          const violations = rootMatches
+            .map((el) => ({
+              selector: describeElement(el),
+              position: getComputedStyle(el).position,
+            }))
+            .filter(
+              (row) => row.position === 'sticky' || row.position === 'fixed',
+            );
+          return {
+            pass: violations.length === 0,
+            scanned: rootMatches.length,
+            violations,
+          };
+        },
+        { navSel: SELECTORS.siteNav },
+      );
+      runs.push({
+        viewport: String(width),
+        mode: 'light',
+        pass: measurement.pass,
+        measurements: measurement,
+      });
+    } finally {
+      await context.close();
+    }
+  }
+
+  results.push({
+    id: 'invariant-5',
+    title: '.site-nav subtree has no sticky/fixed positioning',
+    pass: runs.every((r) => r.pass),
+    runs,
+  });
+  assertAllRunsPassed(
+    'Invariant 5 violated — a .site-nav descendant computes to position: sticky or fixed:',
+    runs,
+  );
+});

--- a/tests/audit/selectors.ts
+++ b/tests/audit/selectors.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared selector constants for the PDR-007 QA-10 audit tooling (Phase 1).
+ *
+ * Consumed by:
+ *   - tests/audit/invariants.spec.ts (QA-10.3) — boolean geometric predicates
+ *     on DOM/CSSOM state at a fixed set of viewports.
+ *   - tests/audit/invariants.reverse.spec.ts (QA-10.3) — demonstrates that
+ *     a deliberately broken fixture produces a measurement-rich failure.
+ *   - Future QA-10.4 DOM cross-sections spec — verified per AC to reuse the
+ *     same selector constants.
+ *
+ * Centralizing the literals here means a future Nav/hero refactor only
+ * needs to update ONE file; the invariant and cross-section suites stay
+ * in lockstep with the source tree.
+ *
+ * Each constant is verified against the current component source:
+ *   - .site-nav, .wordmark, .wordmark-text, .pillar-links, .pillar-link,
+ *     .nav-actions — src/components/Nav.astro
+ *   - .hero-tagline + .hero-tagline .accent — src/pages/index.astro
+ */
+
+export const SELECTORS = {
+  siteNav: '.site-nav',
+  wordmark: '.wordmark',
+  wordmarkText: '.wordmark-text',
+  pillarLinks: '.pillar-links',
+  pillarLink: '.pillar-link',
+  navActions: '.nav-actions',
+  heroTagline: '.hero-tagline',
+  heroTaglineAccent: '.hero-tagline .accent',
+} as const;
+
+export type SelectorKey = keyof typeof SELECTORS;


### PR DESCRIPTION
## Summary

Lands PDR-007 Phase 1 QA-10.3: 5 home-page layout invariants as boolean geometric/CSSOM predicates under a new `audit-invariants` Playwright project. Closes #121.

Invariants exist to catch the failure mode that produced the PR #99 B1 overlap regression — untested assumptions silently rotting. Each predicate is boolean, not pixel-exact, so sub-pixel font-metric drift between macOS and Linux is absorbed by design (per `hq/docs/website/audit-tooling-design.md` § 2.3).

### The 5 invariants

| # | Predicate | Viewports | Modes |
|---|-----------|-----------|-------|
| 1 | Wordmark is the strongest type in `.site-nav` | 320/375/480/768/1024 | light |
| 2 | `--color-accent` resolves to non-empty hex or rgb() | 320/768/1440 | light + dark |
| 3 | `.hero-tagline` first/last visual line each has non-accent text | 320/360/375/414 | light |
| 4 | `.pillar-links` bounding rect does not intersect `.nav-actions` | 320/375/414/480/500/600/640/700/767 | light |
| 5 | No `.site-nav` descendant has computed `position: sticky` or `fixed` | 320/768 | light |

Invariant 4 encodes the exact regression class from PR #99 (flex-wrap: nowrap + active pillar chip obscuring theme-toggle at 480px). Invariant 5 enforces the WCAG SC 2.4.11 Focus Not Obscured exemption noted in QA-08 — valid only while no sticky/fixed elements exist in the nav.

### Changes

- NEW `tests/audit/invariants.spec.ts` — flat suite of 5 named `test()` blocks. Per-viewport iteration in-spec; module-scoped results array + `afterAll` flush to `tests/audit/__reports__/invariants-report.json` (gitignored). Serial mode + project-level `fullyParallel: false` keep report emission deterministic.
- NEW `tests/audit/invariants.reverse.spec.ts` — injects breaking CSS (`.wordmark-text { font-weight: 400 !important }` + `.pillar-link { font-weight: 800 !important }`) and asserts Invariant 1 detects the violation with a measurement-rich message (weights, selectors, text previews). Runs in CI on every push, so detection capability is continuously exercised.
- NEW `tests/audit/helpers.ts` — shared `invariant1Predicate` used by both specs so the reverse spec validates the exact predicate that gates CI, not a copy.
- NEW `tests/audit/selectors.ts` — 8 shared selector constants for invariants spec + QA-10.4 (DOM cross-sections, blocked on this PR per the issue).
- MODIFIED `playwright.config.ts` — registers `audit-invariants` project (testMatch for `audit/invariants*.spec.ts`).
- MODIFIED `package.json` — adds `test:audit:invariants` script.
- MODIFIED `.gitignore` — ignores `tests/audit/__reports__/`.
- MODIFIED `.github/workflows/ci.yml` — updates Playwright step name to include QA-10.3. Existing `npx playwright test` run picks up the new project automatically.

### Quality gates (local)

- `npm run test:audit:invariants`: 6/6 green, stable across 3 consecutive runs.
- `npm run lint`: clean.
- `npm run typecheck`: 0 errors / 0 warnings (2 pre-existing hints unrelated).
- `npm run test`: 38/38 unit tests pass.
- `npm run build`: success.

### Gate coordination

- **Blocks**: QA-10.4 (DOM Cross-Sections) — consumes `tests/audit/selectors.ts` introduced here.
- **Part of**: Phase 1 gate (QA-10.1 + QA-10.2 + QA-10.3 → Phase 2 eligibility).
- **CI integration** (design doc § 6 Item 11) is a separate tracking issue; this PR wires a minimal step-name update and lets the unified `npx playwright test` invocation pick up the new project. A dedicated "QA-10.3" CI step can layer on top if needed.

## Test plan

- [x] `npm run test:audit:invariants` passes all 5 invariants + 1 reverse test
- [x] `tests/audit/__reports__/invariants-report.json` emitted with per-viewport measurements
- [x] Reverse test fails Invariant 1 when CSS injection is applied, with rich measurement output
- [x] Lint / typecheck / build green
- [ ] CI green on PR push (waiting for CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)