### PR TITLE
(chore) add test:audit meta-script family per PDR-007 Phase 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:visual:update": "npm run build && playwright test tests/visual --update-snapshots",
     "test:a11y": "npm run build && playwright test tests/a11y",
     "test:touch-targets": "npm run build && playwright test tests/a11y/touch-targets.spec.ts",
+    "test:audit": "npm run test:audit:routes && npm run test:audit:widths && npm run test:audit:invariants",
+    "test:audit:update": "npm run build && playwright test tests/audit --update-snapshots",
     "test:audit:routes": "npm run build && playwright test --project=audit-routes",
     "test:audit:routes:update": "npm run build && UPDATE_BASELINE=1 playwright test --project=audit-routes",
     "test:audit:invariants": "npm run build && playwright test --project=audit-invariants",

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -88,6 +88,13 @@ Phases are **gates, not schedules** (`hq/docs/decisions/PDR-007-ui-audit-strateg
 
 Governing-section references resolve to `hq/docs/decisions/PDR-007-ui-audit-strategy.md` and `hq/docs/website/audit-tooling-design.md` in the sibling HQ repo. Component scripts and specs land with their owning phase; until a component ships, the surface path above is the committed target, not an existing file.
 
+### Audit script family
+
+`package.json` exposes two meta-scripts that wrap the per-component audit scripts (design reference: `hq/docs/website/audit-tooling-design.md` § 6 Item 10; governing issue: [#126](https://github.com/how-do-i-ai/how-do-i-ai.github.io/issues/126)):
+
+- `npm run test:audit` — runs the audit components serially and exits non-zero on the first failure. As of Phase 1, this executes `test:audit:routes`, `test:audit:widths`, and `test:audit:invariants`. Phase 2 (QA-10.4, QA-10.5) and Phase 3 (QA-10.6) extend this script in their own phase issues as those components land; it is the canonical entry point for "run every audit component that has shipped."
+- `npm run test:audit:update` — invokes `playwright test tests/audit --update-snapshots` to refresh Playwright-captured baselines for audit projects that have them. Phase 1 audit projects produce no Playwright snapshots (routes updates its `route-clusters.json` baseline via a dedicated `test:audit:routes:update` script with `UPDATE_BASELINE=1`; widths and invariants have no baselines), so this is effectively a no-op today. It is wired in now so Phase 2 (QA-10.4 style-sidecar regeneration) and Phase 3 (QA-10.6 rendering-mode PNGs) can extend it without re-architecting the script family.
+
 ### Threshold allowlist (QA-10.2)
 
 Per `hq/docs/decisions/PDR-007-ui-audit-strategy.md` § Constraint 5, QA-10.2's self-generating width list is paired with a reviewer-maintained allowlist at `tests/audit/threshold-significance.json`. Entries carry `threshold_px`, `reason`, `source_file`, `added`, and `review_by` (90-day cadence); expired entries fail the audit. Schema, lifecycle rules, and review cadence are tracked in **[#119](https://github.com/how-do-i-ai/how-do-i-ai.github.io/issues/119)**; design reference at `hq/docs/website/audit-tooling-design.md` § 6 Item 16.
@@ -136,7 +143,7 @@ docker run --rm \
   sh -c "npm ci && npm run test:visual:update"
 ```
 
-The same container will regenerate audit baselines via `npm run test:audit:update` once the audit script family lands (design reference: `hq/docs/website/audit-tooling-design.md` § 6 Item 10). Docker parity for the audit baseline family is tracked in **[#128](https://github.com/how-do-i-ai/how-do-i-ai.github.io/issues/128)**; when that ticket closes a sibling `tests/audit/README.md` may absorb the QA-10-specific portion of this section.
+The same container regenerates Playwright-captured audit baselines via `npm run test:audit:update` — see § Audit script family above for the current Phase 1 no-op caveat. Docker parity for the audit baseline family is tracked in **[#128](https://github.com/how-do-i-ai/how-do-i-ai.github.io/issues/128)**; when that ticket closes a sibling `tests/audit/README.md` may absorb the QA-10-specific portion of this section.
 
 This produces byte-identical baselines to what CI will compare against on the next push. Local regeneration on macOS or Windows is not authoritative — per `hq/docs/website/audit-tooling-design.md` § 5 Risk 3, PRs that touch rendering-mode baselines should state in the commit message that they were regenerated in Docker.
 


### PR DESCRIPTION
Closes #126.

## Summary

Adds the `test:audit` meta-script family to `package.json` per PDR-007 Phase 1 § Item 10. With QA-10.1 (#120), QA-10.2 (#122), and QA-10.3 (#121) all landed, the three component scripts (`test:audit:routes`, `test:audit:widths`, `test:audit:invariants`) now resolve and can be consolidated behind one entry point.

## Changes

- **`package.json`**: two new scripts added as a pair at the top of the audit cluster (meta-first reading order):
  - `test:audit`: runs Phase 1 components serially, fails fast on first non-zero exit.
  - `test:audit:update`: invokes `playwright test tests/audit --update-snapshots` for Playwright-captured baseline refresh.
- **`tests/visual/README.md`**: new `### Audit script family` subsection inside the QA-10 section (per Item 9 / #129 locality) documenting both scripts and the Phase 2/3 extension pattern. Also replaces the stale "once the audit script family lands" forward-reference with a present-tense pointer to the new subsection.

## Phase 1 `test:audit:update` caveat (documented in README)

`test:audit:update` is effectively a no-op today: Phase 1 audit projects don't produce Playwright-captured snapshots. `audit-routes` regenerates its `route-clusters.json` baseline via a dedicated `test:audit:routes:update` with `UPDATE_BASELINE=1`; `widths` uses a reviewer-maintained allowlist; `invariants` has boolean assertions only. The script is wired in now so Phase 2 (QA-10.4 style sidecars) and Phase 3 (QA-10.6 rendering-mode PNGs) can extend it without re-architecting.

## Verification (all AC)

- [x] AC #1a — `test:audit` script body byte-for-byte matches: `npm run test:audit:routes && npm run test:audit:widths && npm run test:audit:invariants`.
- [x] AC #1b — `test:audit:update` script body byte-for-byte matches: `npm run build && playwright test tests/audit --update-snapshots`.
- [x] AC #2 — `&&` chain = serial execution + fail-fast (standard shell semantics).
- [x] AC #3 — Phase 2/3 extension note added inline in `tests/visual/README.md` § Audit script family.
- [x] AC #4 — `npm run test:audit` runs from repo root, no additional flags required.
- [x] AC #5 — `npm run test:audit` exit 0 end-to-end locally (all three Phase 1 components green).

## Test plan

- [ ] CI green on all configured gates (lint, typecheck, unit tests, build, Playwright suites, Lighthouse).
- [ ] `npm run test:audit` succeeds in CI (implicitly via the component scripts already wired into individual CI steps; the meta-script itself isn't wired to a CI step in this PR — that's a follow-up concern tracked with the phase-gates governance at #125).