### PR TITLE
(feat) QA-10.5: OG meta + RSS 2.0 audit per PDR-007 Phase 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,10 @@ jobs:
       # CI-time revisit thresholds in PDR-007. No Phase 1 component
       # uses path-filtering today.
       #
-      # Phase 2 (QA-10.4, QA-10.5) and Phase 3 (QA-10.6) extend this
-      # block in their own tracking issues — not here.
+      # Phase 2 extends this block with QA-10.5 (OG + RSS audit)
+      # as it ships; QA-10.4 (DOM cross-sections) is baked into the
+      # QA-09 Playwright suite and does not add a step here. Phase 3
+      # (QA-10.6) extends this block in its own tracking issue.
       # --------------------------------------------------------------
 
       - name: QA-10.1 — Route clustering
@@ -144,11 +146,15 @@ jobs:
       - name: QA-10.3 — Invariant specs
         run: npm run test:audit:invariants
 
+      - name: QA-10.5 — OG meta + RSS 2.0 audit
+        run: npm run test:audit:og-rss
+
       # Unified artifact upload — covers routes-report.json,
-      # widths-report.json, invariants-report.json. Triggered on
-      # failure only so reviewers can pull per-run reports without
-      # re-running the job. `if-no-files-found: ignore` accommodates
-      # early-failing audits that exit before writing their report.
+      # widths-report.json, invariants-report.json, og-rss-report.json.
+      # Triggered on failure only so reviewers can pull per-run reports
+      # without re-running the job. `if-no-files-found: ignore`
+      # accommodates early-failing audits that exit before writing
+      # their report.
       - name: Upload QA-10 audit reports
         if: failure()
         uses: actions/upload-artifact@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "@playwright/test": "^1.59.1",
         "eslint": "^10.2.0",
         "eslint-plugin-astro": "^1.7.0",
+        "fast-xml-parser": "5.7.1",
+        "gray-matter": "4.0.3",
+        "node-html-parser": "7.1.0",
         "postcss": "8.5.8",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1",
@@ -1841,6 +1844,18 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5216,6 +5231,19 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5365,9 +5393,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -5380,9 +5408,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.10.tgz",
-      "integrity": "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -5391,9 +5419,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.1",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5825,6 +5854,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
@@ -6053,6 +6122,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/html-escaper": {
@@ -6409,6 +6488,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6612,6 +6701,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/legacy-javascript": {
@@ -8057,6 +8156,17 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
     },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
@@ -8463,9 +8573,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -9368,6 +9478,20 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -9815,10 +9939,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:visual:update": "npm run build && playwright test tests/visual --update-snapshots",
     "test:a11y": "npm run build && playwright test tests/a11y",
     "test:touch-targets": "npm run build && playwright test tests/a11y/touch-targets.spec.ts",
-    "test:audit": "npm run test:audit:routes && npm run test:audit:widths && npm run test:audit:invariants",
+    "test:audit": "npm run test:audit:routes && npm run test:audit:widths && npm run test:audit:invariants && npm run test:audit:og-rss",
     "test:audit:update": "npm run build && playwright test tests/audit --update-snapshots",
     "test:audit:routes": "npm run build && playwright test --project=audit-routes",
     "test:audit:routes:update": "npm run build && UPDATE_BASELINE=1 playwright test --project=audit-routes",
@@ -26,7 +26,8 @@
     "format:check": "prettier --check .",
     "typecheck": "astro check",
     "check:playwright-version-parity": "node scripts/check-playwright-version-parity.mjs",
-    "test:audit:widths": "npm run build && node scripts/extract-widths.mjs"
+    "test:audit:widths": "npm run build && node scripts/extract-widths.mjs",
+    "test:audit:og-rss": "npm run build && node scripts/audit-og-rss.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
@@ -40,6 +41,9 @@
     "@playwright/test": "^1.59.1",
     "eslint": "^10.2.0",
     "eslint-plugin-astro": "^1.7.0",
+    "fast-xml-parser": "5.7.1",
+    "gray-matter": "4.0.3",
+    "node-html-parser": "7.1.0",
     "postcss": "8.5.8",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",

--- a/scripts/audit-og-rss.mjs
+++ b/scripts/audit-og-rss.mjs
@@ -230,11 +230,18 @@ export function normalizeUrl(urlStr, site = SITE) {
 
 /**
  * Load every blog post under `src/content/blog/*.md` and return a Map
- * keyed by the post's slug (filename basename without extension —
- * matches Astro content-collection `post.id` / `post.slug`). Draft
- * posts are filtered out; they don't ship to `dist/`, so the audit
- * would otherwise flag them as missing artifacts. Returns the Map
- * plus the full list for downstream iteration.
+ * keyed by slug for downstream lookup/iteration. The slug is the
+ * filename basename without extension — matches Astro content-
+ * collection `post.id` / `post.slug`. Draft posts are filtered out;
+ * they don't ship to `dist/`, so the audit would otherwise flag them
+ * as missing artifacts.
+ *
+ * Date coercion: gray-matter parses YAML date literals (`2025-01-15`)
+ * as `Date` instances and quoted strings (`'2025-01-15'`) as strings.
+ * Both shapes reach this loader; we coerce via `new Date(raw)` so the
+ * downstream RSS pubDate check is applied regardless of how the YAML
+ * was authored. `invalid_date` surfaces as a parsed `NaN`-epoch Date,
+ * which `auditRss` then flags explicitly rather than silently skipping.
  */
 export function loadPosts(blogDir = BLOG_SOURCE_DIR) {
   const bySlug = new Map();
@@ -257,11 +264,22 @@ export function loadPosts(blogDir = BLOG_SOURCE_DIR) {
       throw new Error(`${fullPath}: frontmatter parse failed (${err.message})`);
     }
     if (parsed.data.draft === true) continue;
+    const rawDate = parsed.data.date;
+    let date = null;
+    if (rawDate instanceof Date) {
+      date = rawDate;
+    } else if (rawDate !== undefined && rawDate !== null) {
+      // Coerce strings / numbers. An unparseable value yields an
+      // Invalid Date (getTime() === NaN); `auditRss` surfaces that as
+      // `rss_invalid_pubdate` on the frontmatter side rather than
+      // silently skipping the cross-reference.
+      date = new Date(rawDate);
+    }
     bySlug.set(slug, {
       slug,
       title: parsed.data.title,
       description: parsed.data.description,
-      date: parsed.data.date instanceof Date ? parsed.data.date : null,
+      date,
       source_file: relative(REPO_ROOT, fullPath),
     });
   }
@@ -269,9 +287,10 @@ export function loadPosts(blogDir = BLOG_SOURCE_DIR) {
 }
 
 /**
- * Walk `dist/` and collect every `.html` file. Returns paths relative
- * to the repo root so failure messages point at filesystem locations
- * the author can open directly.
+ * Walk `dist/` and collect every `.html` file. Returns absolute
+ * filesystem paths under `dist/`; callers can convert them to
+ * repo-relative paths via `relative(REPO_ROOT, path)` when formatting
+ * failure messages (the main entry point does this for every page).
  */
 export function globDistHtml(distDir = DIST_DIR) {
   const out = [];
@@ -622,9 +641,16 @@ export function auditRss(xmlContent, posts) {
   const seenSlugs = new Set();
   for (const [i, item] of items.entries()) {
     const itemLabel = `item[${i}]`;
+
+    // 1. Required-field presence check per RSS 2.0. Collect the set of
+    //    fields missing on this item so the downstream cross-reference
+    //    checks can skip them — reporting BOTH `rss_missing_field` and
+    //    a `*_mismatch` for the same field would be noise.
+    const missingFields = new Set();
     for (const field of RSS_ITEM_REQUIRED) {
       const value = item[field];
       if (value === undefined || value === null || value === '') {
+        missingFields.add(field);
         violations.push({
           kind: 'rss_missing_field',
           source: 'dist/rss.xml',
@@ -635,17 +661,25 @@ export function auditRss(xmlContent, posts) {
       }
     }
 
-    const link = item.link ?? '';
-    const slug = slugFromBlogUrl(link);
+    // 2. Slug pairing. If link is missing/empty, the required-field
+    //    check above already emitted `rss_missing_field`; skip the
+    //    slug-derived checks (orphan/unrecognized/duplicate) on this
+    //    item — there's no way to pair it with a source post.
+    if (missingFields.has('link')) {
+      continue;
+    }
+
+    const slug = slugFromBlogUrl(String(item.link));
     if (slug === null) {
-      // Non-blog items would be orphan in the current site — the RSS
-      // only emits blog posts. Surface it rather than silently skip.
+      // Link is present but not of the `/blog/<slug>/` shape — the RSS
+      // only emits blog posts today, so surface it rather than silently
+      // skipping.
       violations.push({
         kind: 'rss_unrecognized_link',
         source: 'dist/rss.xml',
         field: `${itemLabel} > link`,
         expected: `/blog/<slug>/ URL`,
-        actual: link,
+        actual: item.link,
       });
       continue;
     }
@@ -673,9 +707,14 @@ export function auditRss(xmlContent, posts) {
       continue;
     }
 
+    // 3. Per-field cross-reference. Each check is gated on the field
+    //    NOT being in missingFields — a missing field already produced
+    //    a `rss_missing_field` violation; a mismatch violation on the
+    //    same field would be redundant.
+
     // Title — exact equality after normalization (no site-name suffix
     // on RSS item titles).
-    if (item.title !== undefined) {
+    if (!missingFields.has('title')) {
       const actual = normalizeText(String(item.title));
       const expected = normalizeText(post.title);
       if (actual !== expected) {
@@ -690,7 +729,7 @@ export function auditRss(xmlContent, posts) {
     }
 
     // Description — exact equality after normalization.
-    if (item.description !== undefined) {
+    if (!missingFields.has('description')) {
       const actual = normalizeText(String(item.description));
       const expected = normalizeText(post.description);
       if (actual !== expected) {
@@ -705,9 +744,11 @@ export function auditRss(xmlContent, posts) {
     }
 
     // pubDate — epoch-ms equality; frontmatter Date ↔ RSS RFC-822.
-    if (item.pubDate !== undefined && post.date !== null) {
+    // Surface invalid dates on either side explicitly (rather than
+    // silently skipping) so timezone/encoding bugs don't hide.
+    if (!missingFields.has('pubDate')) {
       const rssEpoch = new Date(String(item.pubDate)).getTime();
-      const fmEpoch = post.date.getTime();
+      const fmEpoch = post.date ? post.date.getTime() : NaN;
       if (!Number.isFinite(rssEpoch)) {
         violations.push({
           kind: 'rss_invalid_pubdate',
@@ -715,6 +756,14 @@ export function auditRss(xmlContent, posts) {
           field: `${itemLabel} > pubDate`,
           expected: 'RFC-822 date parseable by new Date()',
           actual: item.pubDate,
+        });
+      } else if (!Number.isFinite(fmEpoch)) {
+        violations.push({
+          kind: 'rss_invalid_pubdate',
+          source: post.source_file,
+          field: `${itemLabel} > pubDate (frontmatter side)`,
+          expected: 'valid date in frontmatter `date` field',
+          actual: post.date === null ? 'missing' : `unparseable (${post.date})`,
         });
       } else if (rssEpoch !== fmEpoch) {
         violations.push({
@@ -728,26 +777,24 @@ export function auditRss(xmlContent, posts) {
     }
 
     // Link — resolved-normalized equality.
-    if (item.link !== undefined) {
-      const actualUrl = normalizeUrl(String(item.link));
-      const expectedUrl = normalizeUrl(`/blog/${slug}/`);
-      if (actualUrl === null) {
-        violations.push({
-          kind: 'invalid_url',
-          source: 'dist/rss.xml',
-          field: `${itemLabel} > link`,
-          expected: 'syntactically-valid URL',
-          actual: item.link,
-        });
-      } else if (actualUrl !== expectedUrl) {
-        violations.push({
-          kind: 'rss_link_mismatch',
-          source: 'dist/rss.xml',
-          field: `${itemLabel} > link`,
-          expected: expectedUrl,
-          actual: actualUrl,
-        });
-      }
+    const actualUrl = normalizeUrl(String(item.link));
+    const expectedUrl = normalizeUrl(`/blog/${slug}/`);
+    if (actualUrl === null) {
+      violations.push({
+        kind: 'invalid_url',
+        source: 'dist/rss.xml',
+        field: `${itemLabel} > link`,
+        expected: 'syntactically-valid URL',
+        actual: item.link,
+      });
+    } else if (actualUrl !== expectedUrl) {
+      violations.push({
+        kind: 'rss_link_mismatch',
+        source: 'dist/rss.xml',
+        field: `${itemLabel} > link`,
+        expected: expectedUrl,
+        actual: actualUrl,
+      });
     }
   }
 

--- a/scripts/audit-og-rss.mjs
+++ b/scripts/audit-og-rss.mjs
@@ -1,0 +1,914 @@
+#!/usr/bin/env node
+// QA-10.5 OG meta + RSS 2.0 audit (Phase 2).
+//
+// Pure-Node audit (no Playwright, no browser). Cross-references two
+// classes of build output — (a) every `dist/**/*.html` page's Open
+// Graph / Twitter / `<title>` / `<meta name="description">` block and
+// (b) `dist/rss.xml` — against the post frontmatter in
+// `src/content/blog/*.md` which is the editorial source-of-truth.
+//
+// Detects drift of the form "OG title on /blog/foo/ says X; frontmatter
+// says Y" that `astro build` cannot catch — the build passes as long
+// as the XML is well-formed and the OG tags are present, regardless of
+// whether the VALUES still match the post source.
+//
+// Audit paths:
+//   1. OG path — glob `dist/**/*.html`; for each page:
+//      (a) structural presence check for required meta tags (runs on
+//          every page — BaseHead.astro emits them universally),
+//      (b) OG-vs-HTML consistency check (og:title and <title> share the
+//          same BaseHead prop; drift is always a bug),
+//      (c) for `/blog/<slug>/` pages only, cross-reference the
+//          rendered OG title / description / canonical URL against the
+//          post's frontmatter title / description / slug-URL.
+//   2. RSS path — parse `dist/rss.xml`; for each channel and each item:
+//      (a) RSS 2.0 required-field presence check (channel: title/link/
+//          description; item: title/description/pubDate/link),
+//      (b) per-item cross-reference of title / description / pubDate
+//          / link against the post's frontmatter. Slug is derived from
+//          the `<link>` URL to pair the item with its source post.
+//
+// Normalization rules (both sides of any string comparison):
+//   1. HTML-decode entities (`&amp;` → `&`, `&quot;` → `"`, numeric
+//      entities). Astro entity-encodes `< > & " '` in attribute values;
+//      frontmatter source does not. Normalization side-levels the
+//      encoding.
+//   2. Unicode-normalize to NFC (absorbs composed vs decomposed
+//      accents).
+//   3. Collapse internal whitespace runs to a single ASCII space.
+//   4. Trim.
+// Comparison is case-sensitive after normalization — Title-Case vs
+// sentence-case is preserved intentionally.
+//
+// Site-name suffix handling:
+//   Blog-post pages pass `${post.data.title} | How Do I AI` as the
+//   BaseHead `title` prop (see `src/pages/blog/[...id].astro`), so
+//   rendered `<title>` and `og:title` both carry the ` | How Do I AI`
+//   suffix on blog-post pages. RSS item `<title>` uses the raw
+//   `post.data.title` with no suffix (see `src/pages/rss.xml.ts`). The
+//   OG-vs-frontmatter comparator strips the suffix if present before
+//   matching; the RSS comparator does not.
+//
+// pubDate comparison:
+//   Frontmatter `date` is parsed by gray-matter as a `Date`; RSS
+//   `<pubDate>` is emitted by @astrojs/rss via `toUTCString()`. Both
+//   parse to the same epoch-millisecond value for midnight-UTC dates.
+//   Comparator uses `getTime()` equality — zero tolerance, any drift
+//   signals a timezone bug worth surfacing loudly.
+//
+// URL comparison:
+//   Both sides are resolved against the configured `site`
+//   (`https://how-do-i.ai`) and enforced to end in a trailing slash
+//   (REQ-INFRA-05 `directory` format). OG `og:url`, `<link
+//   rel="canonical">`, and RSS `<link>` on blog posts must all resolve
+//   to `${site}/blog/${slug}/`.
+//
+// Outputs:
+//   - Markdown report to stdout (captured by the CI log).
+//   - JSON report to `tests/audit/__reports__/og-rss-report.json`
+//     (gitignored).
+//   - Exit 0 if all checks pass, 1 on any violation. Failure message
+//     names the page/item and the field with a side-by-side diff so
+//     the PR author can fix the mismatch at its source.
+//
+// See: issue #133; PDR-007 § Decision Phase 2; audit-tooling-design.md
+// § 2.5, § 5 Risk 5 (dev-dep supply chain); REQ-FEED-01/02/03 (current
+// gate: build success only). HQ repo, private — see CONTRIBUTING.md
+// § Cross-repo setup.
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative, basename, extname } from 'node:path';
+import { parse as parseHtml } from 'node-html-parser';
+import { XMLParser } from 'fast-xml-parser';
+import matter from 'gray-matter';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DIST_DIR = join(REPO_ROOT, 'dist');
+const RSS_PATH = join(DIST_DIR, 'rss.xml');
+const BLOG_SOURCE_DIR = join(REPO_ROOT, 'src/content/blog');
+const REPORT_DIR = join(REPO_ROOT, 'tests/audit/__reports__');
+const REPORT_JSON = join(REPORT_DIR, 'og-rss-report.json');
+
+// Mirrors `astro.config.mjs` `site`. The audit resolves any relative
+// `link` / `og:url` / canonical URL against this origin so
+// `/blog/foo/` and `https://how-do-i.ai/blog/foo/` compare equal.
+export const SITE = 'https://how-do-i.ai';
+
+// Mirrors the blog-post title template in `src/pages/blog/[...id].astro`:
+//   title={`${post.data.title} | How Do I AI`}
+// If rendered `<title>` / `og:title` ends with this suffix, the
+// OG-vs-frontmatter comparator strips it before equality testing.
+// Changing the template on either side requires updating this constant
+// in the same PR.
+export const SITE_NAME_SUFFIX = ' | How Do I AI';
+
+// Required tags on every page — BaseHead.astro emits them universally.
+// Each entry is `[label, selector]`. Kept in author order so the
+// failure report reads top-to-bottom like the rendered HTML.
+const REQUIRED_HTML_TAGS = [
+  ['og:title', 'meta[property="og:title"]'],
+  ['og:description', 'meta[property="og:description"]'],
+  ['og:type', 'meta[property="og:type"]'],
+  ['og:url', 'meta[property="og:url"]'],
+  ['og:image', 'meta[property="og:image"]'],
+  ['twitter:card', 'meta[name="twitter:card"]'],
+  ['canonical', 'link[rel="canonical"]'],
+  ['<title>', 'title'],
+  ['<meta name="description">', 'meta[name="description"]'],
+];
+
+const TWITTER_CARD_EXPECTED = 'summary_large_image';
+
+// --- Normalization ---------------------------------------------------
+
+const HTML_ENTITY_NAMED = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+/**
+ * Decode the subset of HTML entities Astro emits in meta-attribute
+ * content: named entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`,
+ * `&nbsp;`) and numeric entities (decimal `&#39;`, hexadecimal `&#x27;`).
+ * Unknown entities pass through unchanged so a real `&oacute;` in
+ * content surfaces as a literal.
+ */
+export function decodeHtmlEntities(s) {
+  if (typeof s !== 'string') return s;
+  return s.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (match, body) => {
+    if (body[0] === '#') {
+      const code =
+        body[1] === 'x' || body[1] === 'X'
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10);
+      if (!Number.isFinite(code)) return match;
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return match;
+      }
+    }
+    const lower = body.toLowerCase();
+    return Object.prototype.hasOwnProperty.call(HTML_ENTITY_NAMED, lower)
+      ? HTML_ENTITY_NAMED[lower]
+      : match;
+  });
+}
+
+/**
+ * Normalize a text field (OG/Twitter/RSS title or description, HTML
+ * <title>) for equality comparison against frontmatter source. Steps:
+ *   1. HTML-decode entities (side-levels Astro's attribute encoding).
+ *   2. Unicode-normalize to NFC.
+ *   3. Collapse internal whitespace runs to a single ASCII space.
+ *   4. Trim.
+ * Null/undefined/non-string input returns ''.
+ */
+export function normalizeText(s) {
+  if (typeof s !== 'string') return '';
+  const decoded = decodeHtmlEntities(s);
+  const nfc = decoded.normalize('NFC');
+  const collapsed = nfc.replace(/\s+/g, ' ');
+  return collapsed.trim();
+}
+
+/**
+ * Strip the configured site-name suffix if present. Used by the
+ * OG-vs-frontmatter title comparator to pair
+ *   `${post.data.title} | How Do I AI` (rendered)
+ * with
+ *   `${post.data.title}` (frontmatter).
+ * Normalized comparison on both sides ensures a suffix with stray
+ * whitespace / entity encoding still matches.
+ */
+export function stripSiteNameSuffix(title, suffix = SITE_NAME_SUFFIX) {
+  const normalized = normalizeText(title);
+  const normalizedSuffix = normalizeText(suffix);
+  if (normalized.endsWith(normalizedSuffix)) {
+    return normalized
+      .slice(0, normalized.length - normalizedSuffix.length)
+      .trim();
+  }
+  return normalized;
+}
+
+/**
+ * Normalize a URL to absolute-with-trailing-slash form against the
+ * configured site origin. Paths (`/blog/foo/`) resolve to absolute
+ * (`https://how-do-i.ai/blog/foo/`); absolute URLs are re-parsed to
+ * normalize casing on the host. Trailing slash enforced per
+ * REQ-INFRA-05 `directory` build format. Returns `null` if the URL
+ * cannot be parsed — the caller surfaces that as a validation error,
+ * not a matching error.
+ */
+export function normalizeUrl(urlStr, site = SITE) {
+  if (typeof urlStr !== 'string' || urlStr === '') return null;
+  let u;
+  try {
+    u = new URL(urlStr, site);
+  } catch {
+    return null;
+  }
+  const trimmed = u.pathname.replace(/\/+$/, '');
+  // `.html` or a file-extension path should not be forced into a
+  // directory-style trailing slash — but Astro's `directory` build
+  // format emits all blog / about / index routes as directories, not
+  // `.html` files. The trailing slash enforcement matches that format.
+  // For the few internal callers that pass an explicit .html path
+  // (404.html), the path already has an extension and this branch
+  // preserves it.
+  const withSlash = /\.[a-z0-9]+$/i.test(trimmed) ? trimmed : trimmed + '/';
+  return `${u.protocol}//${u.host}${withSlash}${u.search}${u.hash}`;
+}
+
+// --- Source-of-truth loaders ----------------------------------------
+
+/**
+ * Load every blog post under `src/content/blog/*.md` and return a Map
+ * keyed by the post's slug (filename basename without extension —
+ * matches Astro content-collection `post.id` / `post.slug`). Draft
+ * posts are filtered out; they don't ship to `dist/`, so the audit
+ * would otherwise flag them as missing artifacts. Returns the Map
+ * plus the full list for downstream iteration.
+ */
+export function loadPosts(blogDir = BLOG_SOURCE_DIR) {
+  const bySlug = new Map();
+  let entries;
+  try {
+    entries = readdirSync(blogDir, { withFileTypes: true });
+  } catch (err) {
+    throw new Error(
+      `${blogDir}: cannot read (${err.code || err.message}). Is the worktree set up?`,
+    );
+  }
+  for (const e of entries) {
+    if (!e.isFile() || extname(e.name) !== '.md') continue;
+    const slug = basename(e.name, '.md');
+    const fullPath = join(blogDir, e.name);
+    let parsed;
+    try {
+      parsed = matter(readFileSync(fullPath, 'utf8'));
+    } catch (err) {
+      throw new Error(`${fullPath}: frontmatter parse failed (${err.message})`);
+    }
+    if (parsed.data.draft === true) continue;
+    bySlug.set(slug, {
+      slug,
+      title: parsed.data.title,
+      description: parsed.data.description,
+      date: parsed.data.date instanceof Date ? parsed.data.date : null,
+      source_file: relative(REPO_ROOT, fullPath),
+    });
+  }
+  return bySlug;
+}
+
+/**
+ * Walk `dist/` and collect every `.html` file. Returns paths relative
+ * to the repo root so failure messages point at filesystem locations
+ * the author can open directly.
+ */
+export function globDistHtml(distDir = DIST_DIR) {
+  const out = [];
+  function walk(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      throw new Error(
+        `${dir}: cannot read (${err.code || err.message}). Run 'npm run build' first.`,
+      );
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(p);
+      } else if (e.isFile() && p.endsWith('.html')) {
+        out.push(p);
+      }
+    }
+  }
+  walk(distDir);
+  return out.sort();
+}
+
+// --- URL → slug pairing ---------------------------------------------
+
+/**
+ * Pair a rendered HTML page path or RSS item link with its source
+ * post. `/blog/<slug>/` (directory format) is the only blog-post URL
+ * shape the site emits today; everything else returns `null` and the
+ * caller skips the per-post cross-reference.
+ */
+export function slugFromBlogUrl(urlOrPath) {
+  if (typeof urlOrPath !== 'string' || urlOrPath === '') return null;
+  let pathname;
+  try {
+    pathname = new URL(urlOrPath, SITE).pathname;
+  } catch {
+    return null;
+  }
+  const m = pathname.match(/^\/blog\/([^/]+)\/?$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Pair a built HTML file path with its rendered URL. Astro's
+ * `directory` build format emits `/blog/foo/` as
+ * `dist/blog/foo/index.html`; `/404.html` stays as `dist/404.html`.
+ * This function is symmetric with `@astrojs/sitemap`'s path emission.
+ */
+export function urlFromDistHtmlPath(htmlPath, distDir = DIST_DIR) {
+  const rel = relative(distDir, htmlPath).split('\\').join('/');
+  if (rel === 'index.html') return '/';
+  if (rel.endsWith('/index.html')) {
+    return '/' + rel.slice(0, -'index.html'.length);
+  }
+  return '/' + rel;
+}
+
+// --- OG audit --------------------------------------------------------
+
+/**
+ * Extract the meta-tag surface from a built HTML page. Returns both
+ * the raw values (for diff reporting) and the presence verdict (for
+ * the structural check). Missing tags have value `null`.
+ */
+export function extractHtmlMeta(htmlContent) {
+  const root = parseHtml(htmlContent);
+  const pick = (sel) => {
+    const node = root.querySelector(sel);
+    if (!node) return null;
+    if (node.rawTagName.toLowerCase() === 'title') {
+      return node.text;
+    }
+    if (node.rawTagName.toLowerCase() === 'link') {
+      return node.getAttribute('href') ?? null;
+    }
+    return node.getAttribute('content') ?? null;
+  };
+  const presence = {};
+  for (const [label, selector] of REQUIRED_HTML_TAGS) {
+    presence[label] = root.querySelector(selector) !== null;
+  }
+  // twitter:title / twitter:description / twitter:image intentionally
+  // omitted: BaseHead emits them as mirrors of their og:* counterparts
+  // from the same props, so a parity audit would duplicate the og:*
+  // drift checks without adding signal. Revisit if they ever diverge
+  // at emission time.
+  return {
+    ogTitle: pick('meta[property="og:title"]'),
+    ogDescription: pick('meta[property="og:description"]'),
+    ogType: pick('meta[property="og:type"]'),
+    ogUrl: pick('meta[property="og:url"]'),
+    ogImage: pick('meta[property="og:image"]'),
+    twitterCard: pick('meta[name="twitter:card"]'),
+    htmlTitle: pick('title'),
+    metaDescription: pick('meta[name="description"]'),
+    canonical: pick('link[rel="canonical"]'),
+    presence,
+  };
+}
+
+/**
+ * Audit OG/Twitter/title/description tags on every built HTML page.
+ * Produces a flat violations list plus per-page stats. Violations
+ * carry a side-by-side `expected` / `actual` diff so the failure
+ * message can point the author at both sides without further
+ * lookups.
+ */
+export function auditOg(htmlPages, posts) {
+  const violations = [];
+  const perPage = [];
+  for (const { relPath, url, html } of htmlPages) {
+    const meta = extractHtmlMeta(html);
+    const pageViolations = [];
+
+    // Structural check: every required tag must be present.
+    for (const [label] of REQUIRED_HTML_TAGS) {
+      if (!meta.presence[label]) {
+        pageViolations.push({
+          kind: 'missing_tag',
+          page: relPath,
+          url,
+          field: label,
+          expected: 'present',
+          actual: 'missing',
+        });
+      }
+    }
+
+    // twitter:card MUST be `summary_large_image` per BaseHead.astro.
+    if (
+      meta.twitterCard !== null &&
+      normalizeText(meta.twitterCard) !== TWITTER_CARD_EXPECTED
+    ) {
+      pageViolations.push({
+        kind: 'twitter_card_value',
+        page: relPath,
+        url,
+        field: 'twitter:card',
+        expected: TWITTER_CARD_EXPECTED,
+        actual: meta.twitterCard,
+      });
+    }
+
+    // OG image MVP: presence-only + syntactic URL validity.
+    if (meta.ogImage !== null && normalizeUrl(meta.ogImage) === null) {
+      pageViolations.push({
+        kind: 'invalid_url',
+        page: relPath,
+        url,
+        field: 'og:image',
+        expected: 'syntactically-valid URL',
+        actual: meta.ogImage,
+      });
+    }
+
+    // og:title / html <title> consistency — BaseHead passes the same
+    // prop to both, so drift is always a bug.
+    if (meta.ogTitle !== null && meta.htmlTitle !== null) {
+      if (normalizeText(meta.ogTitle) !== normalizeText(meta.htmlTitle)) {
+        pageViolations.push({
+          kind: 'og_html_title_drift',
+          page: relPath,
+          url,
+          field: 'og:title vs <title>',
+          expected: `<title>: ${meta.htmlTitle}`,
+          actual: `og:title: ${meta.ogTitle}`,
+        });
+      }
+    }
+
+    // og:description / meta name=description consistency.
+    if (meta.ogDescription !== null && meta.metaDescription !== null) {
+      if (
+        normalizeText(meta.ogDescription) !==
+        normalizeText(meta.metaDescription)
+      ) {
+        pageViolations.push({
+          kind: 'og_html_description_drift',
+          page: relPath,
+          url,
+          field: 'og:description vs meta description',
+          expected: `meta description: ${meta.metaDescription}`,
+          actual: `og:description: ${meta.ogDescription}`,
+        });
+      }
+    }
+
+    // Per-blog-post cross-reference against frontmatter.
+    const slug = slugFromBlogUrl(url);
+    if (slug !== null) {
+      const post = posts.get(slug);
+      if (!post) {
+        pageViolations.push({
+          kind: 'orphan_blog_page',
+          page: relPath,
+          url,
+          field: 'slug',
+          expected: `a post in ${relative(REPO_ROOT, BLOG_SOURCE_DIR)}/ with basename ${slug}`,
+          actual: 'no matching frontmatter post',
+        });
+      } else {
+        // OG title vs frontmatter title (strip site-name suffix).
+        if (meta.ogTitle !== null) {
+          const stripped = stripSiteNameSuffix(meta.ogTitle);
+          const expected = normalizeText(post.title);
+          if (stripped !== expected) {
+            pageViolations.push({
+              kind: 'og_title_mismatch',
+              page: relPath,
+              url,
+              field: 'og:title',
+              expected: `frontmatter title: ${post.title}`,
+              actual: `og:title (suffix stripped): ${stripped}`,
+            });
+          }
+        }
+
+        // OG description vs frontmatter description.
+        if (meta.ogDescription !== null) {
+          const actual = normalizeText(meta.ogDescription);
+          const expected = normalizeText(post.description);
+          if (actual !== expected) {
+            pageViolations.push({
+              kind: 'og_description_mismatch',
+              page: relPath,
+              url,
+              field: 'og:description',
+              expected: `frontmatter description: ${post.description}`,
+              actual: `og:description: ${meta.ogDescription}`,
+            });
+          }
+        }
+
+        // og:url / canonical vs expected slug URL.
+        const expectedUrl = normalizeUrl(`/blog/${slug}/`);
+        for (const { tag, raw, mismatchKind } of [
+          { tag: 'og:url', raw: meta.ogUrl, mismatchKind: 'og_url_mismatch' },
+          {
+            tag: 'canonical',
+            raw: meta.canonical,
+            mismatchKind: 'canonical_url_mismatch',
+          },
+        ]) {
+          if (raw === null) continue;
+          const actual = normalizeUrl(raw);
+          if (actual === null) {
+            pageViolations.push({
+              kind: 'invalid_url',
+              page: relPath,
+              url,
+              field: tag,
+              expected: 'syntactically-valid URL',
+              actual: raw,
+            });
+          } else if (actual !== expectedUrl) {
+            pageViolations.push({
+              kind: mismatchKind,
+              page: relPath,
+              url,
+              field: tag,
+              expected: expectedUrl,
+              actual,
+            });
+          }
+        }
+      }
+    }
+
+    perPage.push({
+      page: relPath,
+      url,
+      is_blog_post: slug !== null,
+      slug,
+      violation_count: pageViolations.length,
+    });
+    violations.push(...pageViolations);
+  }
+  return { violations, perPage };
+}
+
+// --- RSS audit -------------------------------------------------------
+
+// Channel-level required fields per RSS 2.0.
+const RSS_CHANNEL_REQUIRED = ['title', 'link', 'description'];
+// Item-level required fields per RSS 2.0.
+const RSS_ITEM_REQUIRED = ['title', 'description', 'pubDate', 'link'];
+
+/**
+ * Parse `dist/rss.xml` via fast-xml-parser, normalize item emission
+ * (single-item case returns an object; multi-item returns an array),
+ * and return a structurally uniform shape for the audit.
+ */
+export function parseRss(xmlContent) {
+  // Default XMLParser behaviour is what we want: single-child nodes
+  // flatten to objects, multi-child siblings become arrays. The audit
+  // does not read RSS attributes (e.g. `isPermaLink` on `<guid>`), so
+  // no option overrides are needed.
+  const parser = new XMLParser();
+  const parsed = parser.parse(xmlContent);
+  if (!parsed.rss || !parsed.rss.channel) {
+    return null;
+  }
+  const channel = parsed.rss.channel;
+  const rawItems = channel.item;
+  const items = Array.isArray(rawItems) ? rawItems : rawItems ? [rawItems] : [];
+  return {
+    channel,
+    items,
+  };
+}
+
+/**
+ * Audit `dist/rss.xml`. Validates channel-level + item-level required
+ * fields, then cross-references each item against the matching post's
+ * frontmatter by slug derived from `<link>`.
+ */
+export function auditRss(xmlContent, posts) {
+  const violations = [];
+  const parsed = parseRss(xmlContent);
+  if (parsed === null) {
+    violations.push({
+      kind: 'rss_structure',
+      source: 'dist/rss.xml',
+      field: 'rss > channel',
+      expected: 'present',
+      actual: 'missing',
+    });
+    return { violations, stats: { channel_present: false, items: 0 } };
+  }
+  const { channel, items } = parsed;
+
+  for (const field of RSS_CHANNEL_REQUIRED) {
+    const value = channel[field];
+    if (value === undefined || value === null || value === '') {
+      violations.push({
+        kind: 'rss_missing_field',
+        source: 'dist/rss.xml',
+        field: `channel > ${field}`,
+        expected: 'present',
+        actual: 'missing',
+      });
+    }
+  }
+
+  const seenSlugs = new Set();
+  for (const [i, item] of items.entries()) {
+    const itemLabel = `item[${i}]`;
+    for (const field of RSS_ITEM_REQUIRED) {
+      const value = item[field];
+      if (value === undefined || value === null || value === '') {
+        violations.push({
+          kind: 'rss_missing_field',
+          source: 'dist/rss.xml',
+          field: `${itemLabel} > ${field}`,
+          expected: 'present',
+          actual: 'missing',
+        });
+      }
+    }
+
+    const link = item.link ?? '';
+    const slug = slugFromBlogUrl(link);
+    if (slug === null) {
+      // Non-blog items would be orphan in the current site — the RSS
+      // only emits blog posts. Surface it rather than silently skip.
+      violations.push({
+        kind: 'rss_unrecognized_link',
+        source: 'dist/rss.xml',
+        field: `${itemLabel} > link`,
+        expected: `/blog/<slug>/ URL`,
+        actual: link,
+      });
+      continue;
+    }
+
+    if (seenSlugs.has(slug)) {
+      violations.push({
+        kind: 'rss_duplicate_slug',
+        source: 'dist/rss.xml',
+        field: `${itemLabel} > link`,
+        expected: 'unique slug per item',
+        actual: slug,
+      });
+    }
+    seenSlugs.add(slug);
+
+    const post = posts.get(slug);
+    if (!post) {
+      violations.push({
+        kind: 'rss_orphan_item',
+        source: 'dist/rss.xml',
+        field: `${itemLabel} > slug`,
+        expected: `a post in ${relative(REPO_ROOT, BLOG_SOURCE_DIR)}/ with basename ${slug}`,
+        actual: 'no matching frontmatter post',
+      });
+      continue;
+    }
+
+    // Title — exact equality after normalization (no site-name suffix
+    // on RSS item titles).
+    if (item.title !== undefined) {
+      const actual = normalizeText(String(item.title));
+      const expected = normalizeText(post.title);
+      if (actual !== expected) {
+        violations.push({
+          kind: 'rss_title_mismatch',
+          source: 'dist/rss.xml',
+          field: `${itemLabel} > title`,
+          expected: `frontmatter title: ${post.title}`,
+          actual: `rss title: ${item.title}`,
+        });
+      }
+    }
+
+    // Description — exact equality after normalization.
+    if (item.description !== undefined) {
+      const actual = normalizeText(String(item.description));
+      const expected = normalizeText(post.description);
+      if (actual !== expected) {
+        violations.push({
+          kind: 'rss_description_mismatch',
+          source: 'dist/rss.xml',
+          field: `${itemLabel} > description`,
+          expected: `frontmatter description: ${post.description}`,
+          actual: `rss description: ${item.description}`,
+        });
+      }
+    }
+
+    // pubDate — epoch-ms equality; frontmatter Date ↔ RSS RFC-822.
+    if (item.pubDate !== undefined && post.date !== null) {
+      const rssEpoch = new Date(String(item.pubDate)).getTime();
+      const fmEpoch = post.date.getTime();
+      if (!Number.isFinite(rssEpoch)) {
+        violations.push({
+          kind: 'rss_invalid_pubdate',
+          source: 'dist/rss.xml',
+          field: `${itemLabel} > pubDate`,
+          expected: 'RFC-822 date parseable by new Date()',
+          actual: item.pubDate,
+        });
+      } else if (rssEpoch !== fmEpoch) {
+        violations.push({
+          kind: 'rss_pubdate_mismatch',
+          source: 'dist/rss.xml',
+          field: `${itemLabel} > pubDate`,
+          expected: `frontmatter date (epoch ms): ${fmEpoch} (${post.date.toUTCString()})`,
+          actual: `rss pubDate (epoch ms): ${rssEpoch} (${item.pubDate})`,
+        });
+      }
+    }
+
+    // Link — resolved-normalized equality.
+    if (item.link !== undefined) {
+      const actualUrl = normalizeUrl(String(item.link));
+      const expectedUrl = normalizeUrl(`/blog/${slug}/`);
+      if (actualUrl === null) {
+        violations.push({
+          kind: 'invalid_url',
+          source: 'dist/rss.xml',
+          field: `${itemLabel} > link`,
+          expected: 'syntactically-valid URL',
+          actual: item.link,
+        });
+      } else if (actualUrl !== expectedUrl) {
+        violations.push({
+          kind: 'rss_link_mismatch',
+          source: 'dist/rss.xml',
+          field: `${itemLabel} > link`,
+          expected: expectedUrl,
+          actual: actualUrl,
+        });
+      }
+    }
+  }
+
+  // Coverage — every non-draft post should appear as an RSS item.
+  for (const [slug, post] of posts.entries()) {
+    if (!seenSlugs.has(slug)) {
+      violations.push({
+        kind: 'rss_missing_post',
+        source: 'dist/rss.xml',
+        field: `item[slug=${slug}]`,
+        expected: `item for ${post.source_file}`,
+        actual: 'missing',
+      });
+    }
+  }
+
+  return {
+    violations,
+    stats: { channel_present: true, items: items.length },
+  };
+}
+
+// --- Rendering -------------------------------------------------------
+
+function renderMarkdown(summary, ogResult, rssResult) {
+  const lines = [];
+  lines.push('# QA-10.5 OG + RSS — audit report');
+  lines.push('');
+  lines.push(`- Run date: ${summary.run_date}`);
+  lines.push(`- HTML pages scanned: ${summary.html_pages_scanned}`);
+  lines.push(`- Blog-post pages: ${summary.blog_post_pages}`);
+  lines.push(`- RSS items: ${summary.rss_items}`);
+  lines.push(`- Source posts: ${summary.source_posts}`);
+  lines.push(`- OG violations: ${ogResult.violations.length}`);
+  lines.push(`- RSS violations: ${rssResult.violations.length}`);
+  lines.push('');
+
+  if (ogResult.perPage.length > 0) {
+    lines.push('## Per-page OG verdict');
+    lines.push('');
+    lines.push('| Page | URL | Blog post | Violations |');
+    lines.push('| --- | --- | --- | --- |');
+    for (const p of ogResult.perPage) {
+      lines.push(
+        `| \`${p.page}\` | ${p.url} | ${p.is_blog_post ? 'yes' : 'no'} | ${p.violation_count} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function renderFailureMessage(ogResult, rssResult) {
+  const lines = [];
+  const allViolations = [...ogResult.violations, ...rssResult.violations];
+  if (allViolations.length === 0) return '';
+  lines.push('');
+  lines.push(`QA-10.5 FAIL — ${allViolations.length} violation(s) detected:`);
+  lines.push('');
+  for (const v of allViolations) {
+    const location = v.page
+      ? `${v.page} (${v.url})`
+      : v.source || '(unknown source)';
+    lines.push(`  - [${v.kind}] ${v.field}`);
+    lines.push(`      at:       ${location}`);
+    lines.push(`      expected: ${v.expected}`);
+    lines.push(`      actual:   ${v.actual}`);
+  }
+  lines.push('');
+  lines.push('Resolve each by one of:');
+  lines.push(
+    '  (a) update the frontmatter in src/content/blog/*.md so the source-of-truth matches intent,',
+  );
+  lines.push(
+    '  (b) update the rendering template (BaseHead.astro, rss.xml.ts, or the page layout) so emission matches the frontmatter, or',
+  );
+  lines.push(
+    '  (c) if the mismatch is a site-name suffix / pubDate timezone / URL format bug, fix at the emission layer.',
+  );
+  return lines.join('\n');
+}
+
+// --- JSON output -----------------------------------------------------
+
+function writeJsonReport(summary, ogResult, rssResult) {
+  mkdirSync(REPORT_DIR, { recursive: true });
+  const payload = {
+    run_date: summary.run_date,
+    html_pages_scanned: summary.html_pages_scanned,
+    blog_post_pages: summary.blog_post_pages,
+    rss_items: summary.rss_items,
+    source_posts: summary.source_posts,
+    og: {
+      violations: ogResult.violations,
+      per_page: ogResult.perPage,
+    },
+    rss: {
+      violations: rssResult.violations,
+      channel_present: rssResult.stats.channel_present,
+      item_count: rssResult.stats.items,
+    },
+  };
+  writeFileSync(REPORT_JSON, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+  return REPORT_JSON;
+}
+
+function todayISO() {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export async function main() {
+  const posts = loadPosts();
+
+  const htmlPages = globDistHtml().map((absPath) => ({
+    relPath: relative(REPO_ROOT, absPath),
+    url: urlFromDistHtmlPath(absPath),
+    html: readFileSync(absPath, 'utf8'),
+  }));
+
+  let rssContent;
+  try {
+    rssContent = readFileSync(RSS_PATH, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `${RSS_PATH}: cannot read (${err.code || err.message}). Run 'npm run build' first.`,
+    );
+  }
+
+  const ogResult = auditOg(htmlPages, posts);
+  const rssResult = auditRss(rssContent, posts);
+
+  const summary = {
+    run_date: todayISO(),
+    html_pages_scanned: htmlPages.length,
+    blog_post_pages: ogResult.perPage.filter((p) => p.is_blog_post).length,
+    rss_items: rssResult.stats.items,
+    source_posts: posts.size,
+  };
+
+  process.stdout.write(renderMarkdown(summary, ogResult, rssResult) + '\n');
+  const jsonPath = writeJsonReport(summary, ogResult, rssResult);
+  process.stdout.write(`\nJSON report: ${relative(REPO_ROOT, jsonPath)}\n`);
+
+  const failMsg = renderFailureMessage(ogResult, rssResult);
+  if (failMsg !== '') {
+    process.stderr.write(failMsg + '\n');
+    process.exit(1);
+  }
+}
+
+// CLI invocation — only runs when executed directly, not when imported
+// by the unit test.
+const isCli = process.argv[1] === fileURLToPath(import.meta.url);
+if (isCli) {
+  main().catch((err) => {
+    process.stderr.write(`[audit-og-rss] ERROR: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/audit-og-rss.test.mjs
+++ b/scripts/audit-og-rss.test.mjs
@@ -1,0 +1,663 @@
+// Unit tests for scripts/audit-og-rss.mjs (QA-10.5 OG meta + RSS 2.0
+// audit). Drives the normalization, extraction, and audit logic
+// through in-memory HTML / XML / frontmatter fixtures so the
+// reverse-test AC (modifying an OG title in BaseHead.astro without
+// updating frontmatter — or vice versa — produces a diff-style
+// failure) has an automated enforcement point.
+
+import { describe, it, expect } from 'vitest';
+import {
+  decodeHtmlEntities,
+  normalizeText,
+  stripSiteNameSuffix,
+  normalizeUrl,
+  slugFromBlogUrl,
+  urlFromDistHtmlPath,
+  extractHtmlMeta,
+  auditOg,
+  parseRss,
+  auditRss,
+  SITE,
+  SITE_NAME_SUFFIX,
+} from './audit-og-rss.mjs';
+
+// --- decodeHtmlEntities ---------------------------------------------
+
+describe('decodeHtmlEntities', () => {
+  it('decodes the named entities Astro emits in meta content', () => {
+    expect(decodeHtmlEntities('a &amp; b')).toBe('a & b');
+    expect(decodeHtmlEntities('a &lt;b&gt; c')).toBe('a <b> c');
+    expect(decodeHtmlEntities('it&apos;s')).toBe("it's");
+    expect(decodeHtmlEntities('&quot;x&quot;')).toBe('"x"');
+    // &nbsp; decodes to U+00A0 (non-breaking space). Downstream
+    // normalizeText collapses it to ASCII space along with any other
+    // whitespace (verified below), which is where the audit's comparison
+    // semantics live.
+    expect(decodeHtmlEntities('non&nbsp;break')).toBe('non break');
+  });
+
+  it('decodes &nbsp; such that normalizeText collapses it to an ASCII space', () => {
+    expect(normalizeText('non&nbsp;break')).toBe('non break');
+  });
+
+  it('decodes decimal numeric entities', () => {
+    expect(decodeHtmlEntities('it&#39;s')).toBe("it's");
+    expect(decodeHtmlEntities('a&#38;b')).toBe('a&b');
+  });
+
+  it('decodes hexadecimal numeric entities', () => {
+    expect(decodeHtmlEntities('it&#x27;s')).toBe("it's");
+    expect(decodeHtmlEntities('a&#x26;b')).toBe('a&b');
+  });
+
+  it('passes unknown named entities through unchanged', () => {
+    expect(decodeHtmlEntities('caf&oacute;')).toBe('caf&oacute;');
+  });
+
+  it('is a no-op on empty / non-string input', () => {
+    expect(decodeHtmlEntities('')).toBe('');
+    expect(decodeHtmlEntities(null)).toBeNull();
+    expect(decodeHtmlEntities(undefined)).toBeUndefined();
+  });
+});
+
+// --- normalizeText --------------------------------------------------
+
+describe('normalizeText', () => {
+  it('HTML-decodes, NFC-normalizes, collapses whitespace, and trims', () => {
+    expect(normalizeText('  a &amp; b  ')).toBe('a & b');
+    expect(normalizeText('a\t\n  b')).toBe('a b');
+    expect(normalizeText('   ')).toBe('');
+  });
+
+  it('treats NFD vs NFC as equal via normalization', () => {
+    const nfd = 'café'; // "café" in NFD form
+    const nfc = 'café';
+    expect(normalizeText(nfd)).toBe(normalizeText(nfc));
+  });
+
+  it('returns empty string for null / undefined / non-string input', () => {
+    expect(normalizeText(null)).toBe('');
+    expect(normalizeText(undefined)).toBe('');
+    expect(normalizeText(42)).toBe('');
+  });
+});
+
+// --- stripSiteNameSuffix --------------------------------------------
+
+describe('stripSiteNameSuffix', () => {
+  it('strips the configured site-name suffix when present', () => {
+    expect(
+      stripSiteNameSuffix(
+        'Building Your First AI-Assisted Workflow | How Do I AI',
+      ),
+    ).toBe('Building Your First AI-Assisted Workflow');
+  });
+
+  it('returns the normalized input unchanged when the suffix is absent', () => {
+    expect(stripSiteNameSuffix('How Do I AI')).toBe('How Do I AI');
+    expect(stripSiteNameSuffix('About How Do I AI?')).toBe(
+      'About How Do I AI?',
+    );
+  });
+
+  it('strips the suffix even when the input has HTML-encoded entities', () => {
+    // Astro encodes apostrophes in attribute values: `&apos;` / `&#x27;`.
+    expect(stripSiteNameSuffix('Don&apos;t miss the point | How Do I AI')).toBe(
+      "Don't miss the point",
+    );
+  });
+
+  it('accepts a custom suffix', () => {
+    expect(stripSiteNameSuffix('Post — Site', ' — Site')).toBe('Post');
+  });
+});
+
+// --- normalizeUrl ----------------------------------------------------
+
+describe('normalizeUrl', () => {
+  it('resolves relative URLs against the configured site', () => {
+    expect(normalizeUrl('/blog/foo/')).toBe('https://how-do-i.ai/blog/foo/');
+    expect(normalizeUrl('/blog/foo')).toBe('https://how-do-i.ai/blog/foo/');
+  });
+
+  it('normalizes absolute URLs to trailing-slash form', () => {
+    expect(normalizeUrl('https://how-do-i.ai/blog/foo')).toBe(
+      'https://how-do-i.ai/blog/foo/',
+    );
+    expect(normalizeUrl('https://how-do-i.ai/blog/foo/')).toBe(
+      'https://how-do-i.ai/blog/foo/',
+    );
+  });
+
+  it('preserves file-extension paths without forcing a trailing slash', () => {
+    expect(normalizeUrl('/404.html')).toBe('https://how-do-i.ai/404.html');
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(normalizeUrl('')).toBeNull();
+    expect(normalizeUrl(null)).toBeNull();
+    expect(normalizeUrl(undefined)).toBeNull();
+    // A plain 'not a url' string resolves to the site origin under URL()
+    // semantics, so it is NOT null — this behaviour matches the way the
+    // audit treats recovered relative paths.
+  });
+});
+
+// --- slugFromBlogUrl + urlFromDistHtmlPath --------------------------
+
+describe('slugFromBlogUrl', () => {
+  it('extracts the slug from /blog/<slug>/ URLs', () => {
+    expect(slugFromBlogUrl('/blog/sample-post/')).toBe('sample-post');
+    expect(slugFromBlogUrl('/blog/foo/')).toBe('foo');
+    expect(slugFromBlogUrl('https://how-do-i.ai/blog/sample-post/')).toBe(
+      'sample-post',
+    );
+  });
+
+  it('also matches trailing-slashless variants', () => {
+    expect(slugFromBlogUrl('/blog/sample-post')).toBe('sample-post');
+  });
+
+  it('returns null for non-blog-post URLs', () => {
+    expect(slugFromBlogUrl('/')).toBeNull();
+    expect(slugFromBlogUrl('/about/')).toBeNull();
+    expect(slugFromBlogUrl('/blog/')).toBeNull();
+    expect(slugFromBlogUrl('/blog/foo/bar/')).toBeNull();
+    expect(slugFromBlogUrl('')).toBeNull();
+  });
+});
+
+describe('urlFromDistHtmlPath', () => {
+  it('maps dist directory index.html paths to directory URLs', () => {
+    expect(urlFromDistHtmlPath('/repo/dist/index.html', '/repo/dist')).toBe(
+      '/',
+    );
+    expect(
+      urlFromDistHtmlPath('/repo/dist/blog/index.html', '/repo/dist'),
+    ).toBe('/blog/');
+    expect(
+      urlFromDistHtmlPath(
+        '/repo/dist/blog/sample-post/index.html',
+        '/repo/dist',
+      ),
+    ).toBe('/blog/sample-post/');
+  });
+
+  it('preserves explicit .html paths (e.g., 404.html)', () => {
+    expect(urlFromDistHtmlPath('/repo/dist/404.html', '/repo/dist')).toBe(
+      '/404.html',
+    );
+  });
+});
+
+// --- extractHtmlMeta ------------------------------------------------
+
+const BLOG_HTML_OK = `
+  <html>
+    <head>
+      <meta name="description" content="The description">
+      <link rel="canonical" href="https://how-do-i.ai/blog/sample/">
+      <meta property="og:title" content="Sample Title | How Do I AI">
+      <meta property="og:description" content="The description">
+      <meta property="og:type" content="website">
+      <meta property="og:url" content="https://how-do-i.ai/blog/sample/">
+      <meta property="og:image" content="https://how-do-i.ai/brand/og-default.png">
+      <meta name="twitter:card" content="summary_large_image">
+      <meta name="twitter:title" content="Sample Title | How Do I AI">
+      <meta name="twitter:description" content="The description">
+      <meta name="twitter:image" content="https://how-do-i.ai/brand/og-default.png">
+      <title>Sample Title | How Do I AI</title>
+    </head>
+    <body></body>
+  </html>
+`;
+
+describe('extractHtmlMeta', () => {
+  it('extracts all canonical fields from a well-formed blog-post HTML', () => {
+    const meta = extractHtmlMeta(BLOG_HTML_OK);
+    expect(meta.ogTitle).toBe('Sample Title | How Do I AI');
+    expect(meta.htmlTitle).toBe('Sample Title | How Do I AI');
+    expect(meta.ogDescription).toBe('The description');
+    expect(meta.metaDescription).toBe('The description');
+    expect(meta.ogType).toBe('website');
+    expect(meta.ogUrl).toBe('https://how-do-i.ai/blog/sample/');
+    expect(meta.ogImage).toBe('https://how-do-i.ai/brand/og-default.png');
+    expect(meta.twitterCard).toBe('summary_large_image');
+    expect(meta.canonical).toBe('https://how-do-i.ai/blog/sample/');
+  });
+
+  it('reports all required-tag presence as true when every tag is emitted', () => {
+    const meta = extractHtmlMeta(BLOG_HTML_OK);
+    for (const key of Object.keys(meta.presence)) {
+      expect(meta.presence[key]).toBe(true);
+    }
+  });
+
+  it('reports missing tags as presence=false', () => {
+    const html = '<html><head><title>Only title</title></head></html>';
+    const meta = extractHtmlMeta(html);
+    expect(meta.presence['og:title']).toBe(false);
+    expect(meta.presence['<title>']).toBe(true);
+    expect(meta.ogTitle).toBeNull();
+    expect(meta.htmlTitle).toBe('Only title');
+  });
+});
+
+// --- auditOg --------------------------------------------------------
+
+function mkPost(overrides = {}) {
+  return {
+    slug: 'sample',
+    title: 'Sample Title',
+    description: 'The description',
+    date: new Date('2025-01-15'),
+    source_file: 'src/content/blog/sample.md',
+    ...overrides,
+  };
+}
+
+function mkHtmlPage(overrides = {}) {
+  return {
+    relPath: overrides.relPath ?? 'dist/blog/sample/index.html',
+    url: overrides.url ?? '/blog/sample/',
+    html: overrides.html ?? BLOG_HTML_OK,
+  };
+}
+
+describe('auditOg', () => {
+  it('produces zero violations for a well-formed blog post matching frontmatter', () => {
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg([mkHtmlPage()], posts);
+    expect(result.violations).toEqual([]);
+    expect(result.perPage[0].is_blog_post).toBe(true);
+    expect(result.perPage[0].slug).toBe('sample');
+  });
+
+  it('surfaces missing required tags on any page (structural check)', () => {
+    const posts = new Map();
+    const html = `
+      <html><head><title>Minimal</title></head></html>
+    `;
+    const result = auditOg(
+      [mkHtmlPage({ relPath: 'dist/x.html', url: '/x.html', html })],
+      posts,
+    );
+    const missing = result.violations.filter((v) => v.kind === 'missing_tag');
+    expect(missing.length).toBeGreaterThan(0);
+    expect(missing.find((v) => v.field === 'og:title')).toBeDefined();
+    expect(missing.find((v) => v.field === 'canonical')).toBeDefined();
+  });
+
+  it('flags a twitter:card value other than summary_large_image', () => {
+    const html = BLOG_HTML_OK.replace(
+      'content="summary_large_image"',
+      'content="summary"',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg([mkHtmlPage({ html })], posts);
+    const v = result.violations.find((x) => x.kind === 'twitter_card_value');
+    expect(v).toBeDefined();
+    expect(v.expected).toBe('summary_large_image');
+    expect(v.actual).toBe('summary');
+  });
+
+  it('surfaces OG title drift against frontmatter with a diff-style report', () => {
+    // Reverse-test AC: OG title changed in rendered HTML without a
+    // matching frontmatter update.
+    const html = BLOG_HTML_OK.replace(
+      'content="Sample Title | How Do I AI"',
+      'content="DIFFERENT Title | How Do I AI"',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg([mkHtmlPage({ html })], posts);
+    const v = result.violations.find((x) => x.kind === 'og_title_mismatch');
+    expect(v).toBeDefined();
+    expect(v.field).toBe('og:title');
+    expect(v.expected).toContain('Sample Title');
+    expect(v.actual).toContain('DIFFERENT Title');
+    expect(v.page).toBe('dist/blog/sample/index.html');
+    expect(v.url).toBe('/blog/sample/');
+  });
+
+  it('surfaces frontmatter title drift against rendered OG title (reverse direction)', () => {
+    // Reverse-test AC, reversed: frontmatter edited without re-rendering.
+    const posts = new Map([
+      ['sample', mkPost({ title: 'New Frontmatter Title' })],
+    ]);
+    const result = auditOg([mkHtmlPage()], posts);
+    const v = result.violations.find((x) => x.kind === 'og_title_mismatch');
+    expect(v).toBeDefined();
+    expect(v.expected).toContain('New Frontmatter Title');
+    expect(v.actual).toContain('Sample Title');
+  });
+
+  it('surfaces OG description drift against frontmatter', () => {
+    const html = BLOG_HTML_OK.replaceAll(
+      '"The description"',
+      '"A DIFFERENT description"',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg([mkHtmlPage({ html })], posts);
+    const v = result.violations.find(
+      (x) => x.kind === 'og_description_mismatch',
+    );
+    expect(v).toBeDefined();
+    expect(v.expected).toContain('The description');
+    expect(v.actual).toContain('A DIFFERENT description');
+  });
+
+  it('surfaces og:title vs <title> drift when they share a page but differ', () => {
+    // Simulates a template bug where the two fields desynchronize.
+    const html = BLOG_HTML_OK.replace(
+      '<title>Sample Title | How Do I AI</title>',
+      '<title>Out-of-sync | How Do I AI</title>',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg([mkHtmlPage({ html })], posts);
+    const v = result.violations.find((x) => x.kind === 'og_html_title_drift');
+    expect(v).toBeDefined();
+    expect(v.expected).toContain('Out-of-sync');
+    expect(v.actual).toContain('Sample Title');
+  });
+
+  it('flags blog URLs that do not resolve to a source post (orphan blog page)', () => {
+    const posts = new Map();
+    const result = auditOg([mkHtmlPage()], posts);
+    const v = result.violations.find((x) => x.kind === 'orphan_blog_page');
+    expect(v).toBeDefined();
+  });
+
+  it('skips cross-reference for non-blog pages', () => {
+    const posts = new Map();
+    const result = auditOg(
+      [
+        mkHtmlPage({
+          relPath: 'dist/about/index.html',
+          url: '/about/',
+          // About page has its own descriptions, no frontmatter source.
+          html: BLOG_HTML_OK,
+        }),
+      ],
+      posts,
+    );
+    // No cross-reference should fire; only twitter_card etc structural
+    // checks apply. Given BLOG_HTML_OK has all structural tags, the
+    // non-blog page should have 0 violations.
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags og:url / canonical URL mismatch against the expected slug URL', () => {
+    const html = BLOG_HTML_OK.replaceAll(
+      '"https://how-do-i.ai/blog/sample/"',
+      '"https://how-do-i.ai/blog/wrong/"',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg([mkHtmlPage({ html })], posts);
+    const ogUrlViolation = result.violations.find(
+      (x) => x.kind === 'og_url_mismatch',
+    );
+    const canonicalViolation = result.violations.find(
+      (x) => x.kind === 'canonical_url_mismatch',
+    );
+    expect(ogUrlViolation).toBeDefined();
+    expect(canonicalViolation).toBeDefined();
+  });
+
+  it('flags a syntactically-invalid og:image URL', () => {
+    // URL() cannot parse bare `:` schemes or an isolated `//` — use a
+    // malformed input the WHATWG parser rejects.
+    const html = BLOG_HTML_OK.replace(
+      'content="https://how-do-i.ai/brand/og-default.png"',
+      'content="http://[::invalid"',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg([mkHtmlPage({ html })], posts);
+    const v = result.violations.find(
+      (x) => x.kind === 'invalid_url' && x.field === 'og:image',
+    );
+    expect(v).toBeDefined();
+    expect(v.actual).toBe('http://[::invalid');
+  });
+});
+
+// --- parseRss + auditRss --------------------------------------------
+
+const RSS_OK = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>How Do I AI</title>
+    <description>AI first – for everything you do.</description>
+    <link>https://how-do-i.ai/</link>
+    <item>
+      <title>Sample Title</title>
+      <link>https://how-do-i.ai/blog/sample/</link>
+      <guid isPermaLink="true">https://how-do-i.ai/blog/sample/</guid>
+      <description>The description</description>
+      <pubDate>Wed, 15 Jan 2025 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+describe('parseRss', () => {
+  it('returns channel + items for a well-formed feed with a single item', () => {
+    const parsed = parseRss(RSS_OK);
+    expect(parsed.channel.title).toBe('How Do I AI');
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0].title).toBe('Sample Title');
+  });
+
+  it('returns null when the root <rss><channel> is missing', () => {
+    expect(parseRss('<?xml version="1.0"?><root/>')).toBeNull();
+  });
+
+  it('normalizes multi-item emission to an array', () => {
+    const xml = RSS_OK.replace(
+      '</item>\n  </channel>',
+      `</item>
+      <item>
+        <title>Second</title>
+        <link>https://how-do-i.ai/blog/second/</link>
+        <description>Second desc</description>
+        <pubDate>Thu, 16 Jan 2025 00:00:00 GMT</pubDate>
+      </item>
+    </channel>`,
+    );
+    const parsed = parseRss(xml);
+    expect(parsed.items).toHaveLength(2);
+  });
+});
+
+describe('auditRss', () => {
+  it('produces zero violations for a well-formed feed matching frontmatter', () => {
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(RSS_OK, posts);
+    expect(result.violations).toEqual([]);
+    expect(result.stats.items).toBe(1);
+  });
+
+  it('flags missing channel fields', () => {
+    const xml = RSS_OK.replace(
+      '<description>AI first – for everything you do.</description>',
+      '',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const v = result.violations.find(
+      (x) => x.kind === 'rss_missing_field' && x.field.includes('channel'),
+    );
+    expect(v).toBeDefined();
+  });
+
+  it('flags missing item fields', () => {
+    const xml = RSS_OK.replace(
+      '<description>The description</description>',
+      '',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const v = result.violations.find(
+      (x) => x.kind === 'rss_missing_field' && x.field.includes('item[0]'),
+    );
+    expect(v).toBeDefined();
+  });
+
+  it('surfaces RSS title mismatch against frontmatter', () => {
+    // Reverse-test AC direction for RSS: rss.xml.ts emits a different
+    // title from what the frontmatter declares.
+    const xml = RSS_OK.replace(
+      '<title>Sample Title</title>\n      <link>',
+      '<title>Out of sync</title>\n      <link>',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const v = result.violations.find((x) => x.kind === 'rss_title_mismatch');
+    expect(v).toBeDefined();
+    expect(v.expected).toContain('Sample Title');
+    expect(v.actual).toContain('Out of sync');
+  });
+
+  it('surfaces RSS description mismatch against frontmatter', () => {
+    const posts = new Map([
+      ['sample', mkPost({ description: 'New frontmatter description' })],
+    ]);
+    const result = auditRss(RSS_OK, posts);
+    const v = result.violations.find(
+      (x) => x.kind === 'rss_description_mismatch',
+    );
+    expect(v).toBeDefined();
+    expect(v.expected).toContain('New frontmatter description');
+    expect(v.actual).toContain('The description');
+  });
+
+  it('surfaces pubDate mismatch via epoch-ms equality', () => {
+    const posts = new Map([
+      ['sample', mkPost({ date: new Date('2025-03-20') })],
+    ]);
+    const result = auditRss(RSS_OK, posts);
+    const v = result.violations.find((x) => x.kind === 'rss_pubdate_mismatch');
+    expect(v).toBeDefined();
+    // Both sides surface as RFC-822 UTC strings (the RSS emission
+    // format) + their epoch-ms, so the author can see the time-zone
+    // bug or off-by-one-day issue at a glance.
+    expect(v.expected).toContain('Thu, 20 Mar 2025');
+    expect(v.actual).toContain('Wed, 15 Jan 2025');
+  });
+
+  it('flags a post that has no corresponding RSS item (missing coverage)', () => {
+    const posts = new Map([
+      ['sample', mkPost()],
+      [
+        'other',
+        mkPost({
+          slug: 'other',
+          title: 'Other',
+          source_file: 'src/content/blog/other.md',
+        }),
+      ],
+    ]);
+    const result = auditRss(RSS_OK, posts);
+    const v = result.violations.find(
+      (x) => x.kind === 'rss_missing_post' && x.field.includes('other'),
+    );
+    expect(v).toBeDefined();
+  });
+
+  it('flags a non-blog link in an RSS item as unrecognized', () => {
+    const xml = RSS_OK.replace(
+      '<link>https://how-do-i.ai/blog/sample/</link>',
+      '<link>https://how-do-i.ai/somewhere-else/</link>',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const v = result.violations.find((x) => x.kind === 'rss_unrecognized_link');
+    expect(v).toBeDefined();
+  });
+
+  it('flags two RSS items linking to the same slug as a duplicate', () => {
+    const xml = RSS_OK.replace(
+      '</item>\n  </channel>',
+      `</item>
+      <item>
+        <title>Sample Title</title>
+        <link>https://how-do-i.ai/blog/sample/</link>
+        <description>The description</description>
+        <pubDate>Wed, 15 Jan 2025 00:00:00 GMT</pubDate>
+      </item>
+    </channel>`,
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const v = result.violations.find((x) => x.kind === 'rss_duplicate_slug');
+    expect(v).toBeDefined();
+    expect(v.actual).toBe('sample');
+  });
+
+  it('flags a malformed pubDate string via the rss_invalid_pubdate kind', () => {
+    const xml = RSS_OK.replace(
+      '<pubDate>Wed, 15 Jan 2025 00:00:00 GMT</pubDate>',
+      '<pubDate>not-a-date</pubDate>',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const v = result.violations.find((x) => x.kind === 'rss_invalid_pubdate');
+    expect(v).toBeDefined();
+    expect(v.actual).toBe('not-a-date');
+  });
+});
+
+// --- Reverse-test AC (issue #133) -----------------------------------
+
+// The reverse-test AC from issue #133: modifying an OG title in
+// BaseHead.astro without updating frontmatter (or vice versa) produces
+// a specific diff-style failure.
+describe('reverse-test (issue #133 AC)', () => {
+  it('surfaces OG-vs-frontmatter title drift with a diff-style violation', () => {
+    const htmlWithDriftedOgTitle = BLOG_HTML_OK.replace(
+      'content="Sample Title | How Do I AI"',
+      'content="Typo-prone Title | How Do I AI"',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditOg(
+      [mkHtmlPage({ html: htmlWithDriftedOgTitle })],
+      posts,
+    );
+
+    const violation = result.violations.find(
+      (v) => v.kind === 'og_title_mismatch',
+    );
+    expect(violation).toBeDefined();
+    expect(violation.field).toBe('og:title');
+    expect(violation.page).toBe('dist/blog/sample/index.html');
+    expect(violation.url).toBe('/blog/sample/');
+    // Both sides are in the diff so the author sees where to fix.
+    expect(violation.expected).toContain('Sample Title');
+    expect(violation.actual).toContain('Typo-prone Title');
+  });
+
+  it('surfaces frontmatter-side drift with the same diff structure', () => {
+    const posts = new Map([
+      [
+        'sample',
+        mkPost({ title: 'Sample Title but with a different body wording' }),
+      ],
+    ]);
+    const result = auditOg([mkHtmlPage()], posts);
+
+    const violation = result.violations.find(
+      (v) => v.kind === 'og_title_mismatch',
+    );
+    expect(violation).toBeDefined();
+    expect(violation.expected).toContain('different body wording');
+    expect(violation.actual).toContain('Sample Title');
+  });
+});
+
+// --- Module exports sanity check ------------------------------------
+
+describe('module exports', () => {
+  it('exposes SITE and SITE_NAME_SUFFIX as importable constants', () => {
+    expect(SITE).toBe('https://how-do-i.ai');
+    expect(SITE_NAME_SUFFIX).toBe(' | How Do I AI');
+  });
+});

--- a/scripts/audit-og-rss.test.mjs
+++ b/scripts/audit-og-rss.test.mjs
@@ -604,6 +604,68 @@ describe('auditRss', () => {
     expect(v).toBeDefined();
     expect(v.actual).toBe('not-a-date');
   });
+
+  it('surfaces an unparseable frontmatter date as invalid_pubdate on the source side', () => {
+    // loadPosts coerces frontmatter strings via `new Date(raw)`; an
+    // unparseable string yields an Invalid Date. auditRss surfaces that
+    // as rss_invalid_pubdate rather than silently skipping the check,
+    // so YAML-authoring mistakes don't hide behind a green audit.
+    const posts = new Map([
+      ['sample', mkPost({ date: new Date('not-a-real-date') })],
+    ]);
+    const result = auditRss(RSS_OK, posts);
+    const v = result.violations.find(
+      (x) =>
+        x.kind === 'rss_invalid_pubdate' &&
+        x.field.includes('frontmatter side'),
+    );
+    expect(v).toBeDefined();
+    expect(v.source).toContain('src/content/blog/');
+  });
+
+  it('does not double-report a missing link (skips slug-derived checks)', () => {
+    // Copilot #4: if an item is missing <link>, the required-field
+    // check already emits `rss_missing_field`; the audit must NOT also
+    // emit `rss_unrecognized_link` or `rss_orphan_item` for the same
+    // item (there's no way to pair a linkless item with a post).
+    const xml = RSS_OK.replace(
+      '<link>https://how-do-i.ai/blog/sample/</link>',
+      '',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const missing = result.violations.find(
+      (x) => x.kind === 'rss_missing_field' && x.field.includes('link'),
+    );
+    const unrecognized = result.violations.find(
+      (x) => x.kind === 'rss_unrecognized_link',
+    );
+    const orphan = result.violations.find((x) => x.kind === 'rss_orphan_item');
+    expect(missing).toBeDefined();
+    expect(unrecognized).toBeUndefined();
+    expect(orphan).toBeUndefined();
+  });
+
+  it('does not double-report a missing title (skips mismatch check)', () => {
+    // Copilot #5: if an item is missing <title>, `rss_missing_field`
+    // already fires; a `rss_title_mismatch` on the same field is
+    // redundant. Same principle for description / pubDate.
+    const xml = RSS_OK.replace(
+      '<title>Sample Title</title>\n      <link>',
+      '<title></title>\n      <link>',
+    );
+    const posts = new Map([['sample', mkPost()]]);
+    const result = auditRss(xml, posts);
+    const missing = result.violations.find(
+      (x) =>
+        x.kind === 'rss_missing_field' && x.field.includes('item[0] > title'),
+    );
+    const mismatch = result.violations.find(
+      (x) => x.kind === 'rss_title_mismatch',
+    );
+    expect(missing).toBeDefined();
+    expect(mismatch).toBeUndefined();
+  });
 });
 
 // --- Reverse-test AC (issue #133) -----------------------------------


### PR DESCRIPTION
Closes #133.

## Summary

New pure-Node audit `scripts/audit-og-rss.mjs` cross-references every
built `dist/**/*.html` OG / Twitter / `<title>` / meta-description block
and `dist/rss.xml` items against `src/content/blog/*.md` frontmatter.
The audit catches drift that `astro build` cannot — build passes on
well-formed XML and present OG tags regardless of whether the VALUES
still match the post source.

Exits 0 on clean, 1 on any violation with a side-by-side diff naming
the page/item, the field, and both sides so the author can fix at
source.

## Design reference

`hq/docs/website/audit-tooling-design.md` § 2.5; PDR-007 § Decision
Phase 2 (private HQ repo — see CONTRIBUTING.md § Cross-repo setup).

## AC coverage (issue #133)

| # | AC | Evidence |
|---|----|----------|
| 1 | Pure-Node `scripts/audit-og-rss.mjs` | No Playwright / browser imports |
| 2 | OG path — glob, parse via `node-html-parser`, extract, structural check, cross-ref | `globDistHtml` + `extractHtmlMeta` + `auditOg`; 9 presence checks; title/description/URL cross-ref |
| 3 | RSS path — parse via `fast-xml-parser`, RSS 2.0 fields, cross-ref | `parseRss` + `auditRss`; channel + item required fields; 4-field cross-ref |
| 4 | `gray-matter` as explicit devDep | `package.json#devDependencies."gray-matter"` |
| 5 | All 3 new deps pinned (no `^`) | `node-html-parser@7.1.0`, `fast-xml-parser@5.7.1`, `gray-matter@4.0.3` |
| 6 | Markdown stdout report with stats, per-post verdict, per-violation diff | `renderMarkdown` + `renderFailureMessage` |
| 7 | JSON report to gitignored path | `tests/audit/__reports__/og-rss-report.json` (path in `.gitignore:20`) |
| 8 | No committed baselines | Source-of-truth is `src/content/blog/*.md` |
| 9 | `test:audit:og-rss` script + extended `test:audit` | Both in `package.json` |
| 10 | CI step after Phase 1 | `QA-10.5 — OG meta + RSS 2.0 audit` added after QA-10.3 |
| 11 | Reverse-test produces diff-style failure | 3 dedicated unit tests + integration-tested end-to-end |

Refinement cross-ref rules (title/description normalization via
HTML-decode → NFC → whitespace-collapse → trim; pubDate epoch-ms
equality; URL resolution + trailing-slash enforcement; slug exact
match; image presence-only MVP; tags MVP-skip) all implemented and
unit-tested.

## Test plan

- [ ] CI `QA-10.5 — OG meta + RSS 2.0 audit` step green on a build
      that has OG/RSS matching frontmatter (expected nominal state)
- [ ] CI remains green across the other QA-10 Phase 1 steps — nothing
      in this PR touches their configuration
- [ ] Unit tests pass (113 total, 49 new from `scripts/audit-og-rss.test.mjs`)
- [ ] `npm audit --omit=dev` reports 0 vulnerabilities after the 3
      new devDeps
- [ ] Lint, typecheck, build unchanged
- [ ] Manual reverse test: mutating `sample-post.md` frontmatter
      title produces a diff-style failure on both the OG path AND the
      RSS path, each naming the page/item, field, expected, actual

🤖 Generated with [Claude Code](https://claude.com/claude-code)