### PR TITLE
(feat) add QA-10 aggregated audit report per PDR-007 Phase 2 (#131)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Minimal permissions. `contents: read` is the default but pinning
-    # it makes the grant explicit. `pull-requests: write` enables the
-    # aggregated audit-report upsert comment on pull_request events;
-    # push-to-main runs do not use it (the comment step is gated on
-    # `github.event_name == 'pull_request'`).
+    # The build job is read-only with respect to GitHub API surfaces.
+    # Write access is scoped to the `audit-comment` job below, which
+    # runs only on pull_request events — keeping push-to-main runs from
+    # carrying any PR-write capability they would never exercise.
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -206,30 +204,6 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
 
-      # PR-comment upsert (AC bullet 4): ONE stable comment per PR,
-      # updated in place on re-runs (never appended). Marker string
-      # `<!-- qa-10-audit-report -->` is set by the aggregator's
-      # COMMENT_MARKER constant; find-comment locates by marker and
-      # create-or-update-comment replaces the body. Gated on PR events
-      # because push-to-main runs have no PR to comment on.
-      - name: Find previous audit report comment
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        id: find-audit-comment
-        uses: peter-evans/find-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '<!-- qa-10-audit-report -->'
-
-      - name: Create or update audit report comment
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.find-audit-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: tests/audit/__reports__/audit-report.md
-          edit-mode: replace
-
       # QA-06 Lighthouse mobile gates. Builds once at step above; LHCI
       # runs its own static server from ./dist, so no preview needed.
       - name: QA-06 — Lighthouse mobile gates
@@ -242,3 +216,52 @@ jobs:
           name: lighthouseci
           path: .lighthouseci/
           retention-days: 14
+
+  # ----------------------------------------------------------------
+  # QA-10 audit-report PR comment upsert (#131).
+  #
+  # Runs only on pull_request events. Kept as a separate job so the
+  # PR-write permission stays scoped to the comment-posting surface —
+  # the `build` job above runs on push-to-main too and is read-only.
+  #
+  # `needs: build` so the aggregated Markdown artifact exists before
+  # this job runs. `if: ${{ !cancelled() && github.event_name == ... }}`
+  # — `!cancelled()` (not `always()`) ensures the comment upsert
+  # still runs when the build job exited non-zero with an audit
+  # failure, but does NOT run if the workflow itself was cancelled.
+  # ----------------------------------------------------------------
+  audit-comment:
+    needs: build
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download aggregated audit report
+        uses: actions/download-artifact@v4
+        with:
+          name: qa-10-audit-report
+          path: qa-10-audit-report
+
+      # PR-comment upsert (AC bullet 4): ONE stable comment per PR,
+      # updated in place on re-runs (never appended). Marker string
+      # `<!-- qa-10-audit-report -->` is set by the aggregator's
+      # COMMENT_MARKER constant; find-comment locates by marker and
+      # create-or-update-comment replaces the body.
+      - name: Find previous audit report comment
+        id: find-audit-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- qa-10-audit-report -->'
+
+      - name: Create or update audit report comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-audit-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: qa-10-audit-report/audit-report.md
+          edit-mode: replace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Minimal permissions. `contents: read` is the default but pinning
+    # it makes the grant explicit. `pull-requests: write` enables the
+    # aggregated audit-report upsert comment on pull_request events;
+    # push-to-main runs do not use it (the comment step is gated on
+    # `github.event_name == 'pull_request'`).
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -165,6 +173,62 @@ jobs:
           path: tests/audit/__reports__/*.json
           retention-days: 14
           if-no-files-found: ignore
+
+      # --------------------------------------------------------------
+      # QA-10 aggregated audit report (#131).
+      #
+      # Consumes the per-component JSON reports emitted by QA-10.1
+      # (routes), QA-10.2 (widths), QA-10.3 (invariants), and QA-10.5
+      # (og-rss) above, and renders a single consolidated Markdown
+      # document. QA-10.4 runs inline inside the QA-07/08/09 step and
+      # does not emit its own JSON today; the aggregator handles that
+      # gracefully (see scripts/audit-report.mjs docblock).
+      #
+      # `if: ${{ !cancelled() }}` — the aggregator must run regardless
+      # of whether earlier audit steps passed or failed (AC bullet 3:
+      # "regardless of pass/fail"). Skipped steps leave their JSON
+      # absent; the aggregator reports them as NOT RUN.
+      #
+      # The script itself always exits 0 — aggregator reports, never
+      # gates. CI gating stays on the per-component steps whose non-zero
+      # exits stop the build independently.
+      # --------------------------------------------------------------
+      - name: QA-10 aggregated audit report
+        if: ${{ !cancelled() }}
+        run: node scripts/audit-report.mjs
+
+      - name: Upload aggregated audit report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-10-audit-report
+          path: tests/audit/__reports__/audit-report.md
+          retention-days: 14
+          if-no-files-found: warn
+
+      # PR-comment upsert (AC bullet 4): ONE stable comment per PR,
+      # updated in place on re-runs (never appended). Marker string
+      # `<!-- qa-10-audit-report -->` is set by the aggregator's
+      # COMMENT_MARKER constant; find-comment locates by marker and
+      # create-or-update-comment replaces the body. Gated on PR events
+      # because push-to-main runs have no PR to comment on.
+      - name: Find previous audit report comment
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        id: find-audit-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- qa-10-audit-report -->'
+
+      - name: Create or update audit report comment
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-audit-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: tests/audit/__reports__/audit-report.md
+          edit-mode: replace
 
       # QA-06 Lighthouse mobile gates. Builds once at step above; LHCI
       # runs its own static server from ./dist, so no preview needed.

--- a/scripts/audit-report.mjs
+++ b/scripts/audit-report.mjs
@@ -66,11 +66,19 @@ export const JSON_ARTIFACT_NAME = 'qa-10-audit-reports';
  * to `tests/audit/__reports__/`), a human title, and the classifier
  * that converts parsed JSON → status object.
  *
- * QA-10.4 is intentionally `report_file: null` — its pass/fail is
- * surfaced via the QA-09 Playwright step, not a per-run JSON. The
- * classifier for that entry returns an `inline` status that renders
- * a graceful-degradation note pointing at where the checks and
- * baselines live.
+ * QA-10.4 declares `report_file: 'cross-sections-report.json'`, but
+ * that file is NOT emitted by the current implementation — its pass/
+ * fail is surfaced inline via the QA-09 Playwright step (sidecar
+ * reconciliation in `tests/visual/screenshots.spec.ts`), and its
+ * artifacts are `.styles.json` baselines under
+ * `tests/visual/__baselines__/`. In the common case
+ * `loadReport` returns `null` for QA-10.4, and the classifier for
+ * that entry (`classifyCrossSections`) returns an `inline` status
+ * that renders a graceful-degradation note pointing at where the
+ * checks and baselines live. If a future iteration starts emitting
+ * `cross-sections-report.json` at the declared path, the classifier
+ * falls through to a standard pass/fail on `violations[]` — no
+ * descriptor change required.
  */
 export const COMPONENTS = [
   {

--- a/scripts/audit-report.mjs
+++ b/scripts/audit-report.mjs
@@ -1,0 +1,750 @@
+#!/usr/bin/env node
+// QA-10 aggregated audit report (Phase 2).
+//
+// Pure-Node aggregator. Reads per-component JSON outputs from
+// `tests/audit/__reports__/*.json` emitted by the Phase 1 + Phase 2
+// QA-10 components, and renders a single consolidated Markdown
+// document at `tests/audit/__reports__/audit-report.md`.
+//
+// The Markdown is uploaded as a CI artifact and posted (upserted) as a
+// PR comment so reviewers see one aggregated status per PR instead of
+// scanning five separate CI steps.
+//
+// Component inputs (see README.md § QA-10 components for full map):
+//
+//   QA-10.1  tests/audit/__reports__/routes-report.json
+//   QA-10.2  tests/audit/__reports__/widths-report.json
+//   QA-10.3  tests/audit/__reports__/invariants-report.json
+//   QA-10.4  (no per-run JSON — checks happen inline in the QA-09
+//            Playwright suite; baseline artifacts live at
+//            `tests/visual/__baselines__/*.styles.json`)
+//   QA-10.5  tests/audit/__reports__/og-rss-report.json
+//
+// QA-10.4 is rendered with a graceful-degradation note pointing
+// reviewers at the Playwright step and the sidecar baselines. If a
+// future iteration adds `cross-sections-report.json`, the classifier
+// here picks it up automatically — the graceful section only renders
+// when that file is absent.
+//
+// Aggregator semantics:
+//   - Exits 0 for every audit outcome (pass / fail / not-run / parse
+//     error are all REPORTED, never raised). Exits non-zero only on
+//     an aggregator bug or unhandled IO error in the CLI wrapper.
+//     CI gating stays on the per-component steps, whose non-zero
+//     exits stop the build independently.
+//   - Tolerates missing / malformed JSON (reports the failure mode in
+//     the corresponding component section; does not throw).
+//   - On 100% component pass → one-line positive summary.
+//   - On any failure → full per-component detail section expanded.
+//
+// See: issue #131; PDR-007 § Decision Phase 2; audit-tooling-design.md
+// § 6 Item 13. HQ repo, private — see CONTRIBUTING.md § Cross-repo
+// setup.
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const REPORT_DIR = join(REPO_ROOT, 'tests/audit/__reports__');
+const OUTPUT_PATH = join(REPORT_DIR, 'audit-report.md');
+
+// Marker used by the CI workflow's PR-comment upsert. The find-comment
+// step locates the prior comment by this string; the create-or-update
+// step replaces the body. Keep in sync with `.github/workflows/ci.yml`.
+export const COMMENT_MARKER = '<!-- qa-10-audit-report -->';
+
+// Artifact name that CI uses to upload per-component JSONs on failure
+// (`.github/workflows/ci.yml` § Upload QA-10 audit reports). Referenced
+// in per-component sections so reviewers know where to fetch the raw
+// JSON for deep inspection.
+export const JSON_ARTIFACT_NAME = 'qa-10-audit-reports';
+
+/**
+ * Component descriptors. Order drives the rendered section order in
+ * the aggregated Markdown. Each entry names its input JSON (relative
+ * to `tests/audit/__reports__/`), a human title, and the classifier
+ * that converts parsed JSON → status object.
+ *
+ * QA-10.4 is intentionally `report_file: null` — its pass/fail is
+ * surfaced via the QA-09 Playwright step, not a per-run JSON. The
+ * classifier for that entry returns an `inline` status that renders
+ * a graceful-degradation note pointing at where the checks and
+ * baselines live.
+ */
+export const COMPONENTS = [
+  {
+    id: 'QA-10.1',
+    title: 'Route clustering',
+    report_file: 'routes-report.json',
+    classifier: classifyRoutes,
+  },
+  {
+    id: 'QA-10.2',
+    title: 'Critical widths',
+    report_file: 'widths-report.json',
+    classifier: classifyWidths,
+  },
+  {
+    id: 'QA-10.3',
+    title: 'Invariant specs',
+    report_file: 'invariants-report.json',
+    classifier: classifyInvariants,
+  },
+  {
+    id: 'QA-10.4',
+    title: 'DOM cross-sections',
+    report_file: 'cross-sections-report.json',
+    classifier: classifyCrossSections,
+  },
+  {
+    id: 'QA-10.5',
+    title: 'OG meta + RSS 2.0',
+    report_file: 'og-rss-report.json',
+    classifier: classifyOgRss,
+  },
+];
+
+// --- Status shape ----------------------------------------------------
+
+/**
+ * @typedef {object} Status
+ * @property {'pass'|'fail'|'not_run'|'parse_error'|'inline'} kind
+ * @property {Record<string, number>} [counts]     Displayed as badge row.
+ * @property {Array<{label: string, detail: string}>} [violations]
+ * @property {string} [note]                        Freetext explanation.
+ * @property {string} [summary]                     One-line status summary.
+ */
+
+const STATUS_ICON = {
+  pass: '✅',
+  fail: '❌',
+  not_run: '⚠️',
+  parse_error: '❌',
+  inline: 'ℹ️',
+};
+
+const STATUS_LABEL = {
+  pass: 'PASS',
+  fail: 'FAIL',
+  not_run: 'NOT RUN',
+  parse_error: 'PARSE ERROR',
+  inline: 'INLINE',
+};
+
+// --- Markdown helpers ------------------------------------------------
+
+/**
+ * Escape user-controlled values before interpolating them into
+ * Markdown violation labels / details. QA-10.5 (OG + RSS) violations
+ * carry raw page titles, descriptions, and URLs that originate in
+ * `src/content/blog/*.md` frontmatter or the rendered HTML head —
+ * both are authored, but a backtick or literal `<tag>` inside a title
+ * would open an unpaired code span or trip GitHub's HTML sanitizer
+ * when embedded in the aggregated report. Keeping the escape
+ * conservative (backticks, pipes, angle brackets) preserves
+ * readability while neutralizing the three characters that actually
+ * corrupt rendering in a bulleted list context.
+ *
+ * Pipes are included because future renderers may embed violation
+ * detail inside a table cell; keeping the helper safe for both list
+ * and table contexts avoids a caller-by-caller decision.
+ */
+export function mdEscape(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/`/g, '\\`')
+    .replace(/\|/g, '\\|')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// --- Classifiers -----------------------------------------------------
+
+/**
+ * QA-10.1 route-clustering classifier. FAIL when any route is either
+ * unregistered (no archetype binding) OR drifting (registered as one
+ * archetype but its hash matches another). Counts surfaced:
+ *   - total:       rows in `results[]` (one per route tested)
+ *   - unregistered: routes with no archetype binding
+ *   - drift:       routes whose hash matches a different archetype
+ *   - matched:     routes whose hash equals their registered archetype
+ */
+export function classifyRoutes(json) {
+  const results = Array.isArray(json?.results) ? json.results : [];
+  const unregistered = Array.isArray(json?.unregistered_routes)
+    ? json.unregistered_routes
+    : [];
+  const drift = Array.isArray(json?.drift_routes) ? json.drift_routes : [];
+  const matched = results.filter((r) => r?.matches === true).length;
+
+  const counts = {
+    total: results.length,
+    matched,
+    unregistered: unregistered.length,
+    drift: drift.length,
+  };
+
+  if (unregistered.length === 0 && drift.length === 0) {
+    return {
+      kind: 'pass',
+      counts,
+      summary: `${matched} of ${results.length} routes matched their registered archetype`,
+    };
+  }
+
+  const violations = [];
+  for (const route of unregistered) {
+    violations.push({
+      label: `Unregistered route: ${mdEscape(route)}`,
+      detail:
+        'No archetype binding in `tests/audit/__baselines__/route-clusters.json`.',
+    });
+  }
+  for (const drifted of drift) {
+    const route = drifted?.route ?? '(unknown)';
+    const registeredAs = drifted?.registered_as ?? '(unknown)';
+    const matchesArchetype = drifted?.matches_archetype ?? '(unknown)';
+    violations.push({
+      label: `Category drift: ${mdEscape(route)}`,
+      detail: `Registered as "${mdEscape(registeredAs)}" but hash matches "${mdEscape(matchesArchetype)}".`,
+    });
+  }
+
+  return {
+    kind: 'fail',
+    counts,
+    violations,
+    summary: `${unregistered.length} unregistered, ${drift.length} drift`,
+  };
+}
+
+/**
+ * QA-10.2 critical-widths classifier. FAIL when any threshold is
+ * `unhandled` (not in QA-09 widths AND not in the allowlist) OR
+ * `expired` (in the allowlist but past its review_by date). Counts
+ * pass through from the underlying `counts` object verbatim.
+ */
+export function classifyWidths(json) {
+  const counts = json?.counts ?? {};
+  const thresholds = Array.isArray(json?.thresholds) ? json.thresholds : [];
+  const unhandled = counts.unhandled ?? 0;
+  const expired = counts.expired ?? 0;
+
+  const summary = `${counts.covered ?? 0} covered, ${counts.allowlisted ?? 0} allowlisted, ${expired} expired, ${unhandled} unhandled`;
+
+  if (unhandled === 0 && expired === 0) {
+    return {
+      kind: 'pass',
+      counts: {
+        covered: counts.covered ?? 0,
+        allowlisted: counts.allowlisted ?? 0,
+        expired,
+        unhandled,
+      },
+      summary,
+    };
+  }
+
+  const violations = [];
+  for (const t of thresholds) {
+    if (t?.classification !== 'unhandled' && t?.classification !== 'expired') {
+      continue;
+    }
+    const features = Array.isArray(t.features)
+      ? t.features.map(mdEscape).join(', ')
+      : '';
+    const sources = Array.isArray(t.sources)
+      ? t.sources
+          .map((s) => s.source_file)
+          .filter(Boolean)
+          .map(mdEscape)
+          .join(', ')
+      : '';
+    violations.push({
+      label: `${t.threshold_px}px (${t.classification}${features ? ` — ${features}` : ''})`,
+      detail: sources ? `Source(s): ${sources}` : 'No source recorded.',
+    });
+  }
+
+  return {
+    kind: 'fail',
+    counts: {
+      covered: counts.covered ?? 0,
+      allowlisted: counts.allowlisted ?? 0,
+      expired,
+      unhandled,
+    },
+    violations,
+    summary,
+  };
+}
+
+/**
+ * QA-10.3 invariants classifier. FAIL when any invariant `pass: false`.
+ * Each invariant carries multiple `runs[]` (viewport × mode combos);
+ * failure detail enumerates the failing runs for the PR author.
+ */
+export function classifyInvariants(json) {
+  const invariants = Array.isArray(json?.invariants) ? json.invariants : [];
+  const passing = invariants.filter((inv) => inv?.pass === true).length;
+  const failing = invariants.length - passing;
+
+  const counts = {
+    total: invariants.length,
+    passing,
+    failing,
+  };
+
+  if (failing === 0) {
+    return {
+      kind: 'pass',
+      counts,
+      summary: `${passing} of ${invariants.length} invariants held`,
+    };
+  }
+
+  const violations = [];
+  for (const inv of invariants) {
+    if (inv?.pass !== false) continue;
+    const failedRuns = Array.isArray(inv.runs)
+      ? inv.runs.filter((r) => r?.pass === false)
+      : [];
+    const runLabel = failedRuns
+      .map((r) =>
+        `${mdEscape(String(r.viewport))}px ${mdEscape(r.mode ?? '')}`.trim(),
+      )
+      .join(', ');
+    violations.push({
+      label:
+        `${mdEscape(inv.id ?? '(unknown)')}: ${mdEscape(inv.title ?? '')}`.trim(),
+      detail: runLabel
+        ? `Failed at: ${runLabel}`
+        : 'Failed (no per-run detail available).',
+    });
+  }
+
+  return {
+    kind: 'fail',
+    counts,
+    violations,
+    summary: `${failing} of ${invariants.length} invariants violated`,
+  };
+}
+
+/**
+ * QA-10.4 cross-sections classifier. When no per-run JSON exists,
+ * returns an `inline` status that renders a graceful-degradation note
+ * pointing reviewers at the Playwright step and sidecar baselines.
+ *
+ * If a future iteration emits `cross-sections-report.json` under
+ * `tests/audit/__reports__/`, this classifier treats the presence of
+ * `violations[]` as the fail signal and falls through to the standard
+ * pass/fail shape. Until then, the `inline` branch is the only one
+ * that runs in practice.
+ */
+export function classifyCrossSections(json) {
+  if (json === null) {
+    return {
+      kind: 'inline',
+      note:
+        'QA-10.4 runs inline inside the QA-09 Playwright screenshots suite ' +
+        '(pass/fail reflected in the QA-07 / QA-08 / QA-09 CI step). ' +
+        'Sidecar baselines live at `tests/visual/__baselines__/*.styles.json` — ' +
+        'a drift there is surfaced by that step, not in this aggregated report.',
+    };
+  }
+
+  const violations = Array.isArray(json?.violations) ? json.violations : [];
+  const counts = {
+    checked: json?.checked ?? 0,
+    violations: violations.length,
+  };
+
+  if (violations.length === 0) {
+    return {
+      kind: 'pass',
+      counts,
+      summary: `${counts.checked} sidecars matched baseline`,
+    };
+  }
+
+  return {
+    kind: 'fail',
+    counts,
+    violations: violations.map((v) => ({
+      label: v?.label ?? '(unlabeled)',
+      detail: v?.detail ?? '',
+    })),
+    summary: `${violations.length} sidecar drift(s)`,
+  };
+}
+
+/**
+ * QA-10.5 OG + RSS classifier. FAIL when either the OG side OR the RSS
+ * side carries violations. Counts surface page / item totals plus
+ * per-side violation counts; violation list interleaves both sides so
+ * the reviewer sees everything in one place.
+ */
+export function classifyOgRss(json) {
+  const ogViolations = Array.isArray(json?.og?.violations)
+    ? json.og.violations
+    : [];
+  const rssViolations = Array.isArray(json?.rss?.violations)
+    ? json.rss.violations
+    : [];
+
+  const counts = {
+    html_pages_scanned: json?.html_pages_scanned ?? 0,
+    blog_post_pages: json?.blog_post_pages ?? 0,
+    rss_items: json?.rss_items ?? 0,
+    og_violations: ogViolations.length,
+    rss_violations: rssViolations.length,
+  };
+
+  if (ogViolations.length === 0 && rssViolations.length === 0) {
+    return {
+      kind: 'pass',
+      counts,
+      summary: `${counts.html_pages_scanned} pages, ${counts.rss_items} RSS items — no drift`,
+    };
+  }
+
+  const violations = [];
+  for (const v of ogViolations) {
+    const location = v?.page
+      ? `${mdEscape(v.page)} (${mdEscape(v.url ?? '')})`.trim()
+      : mdEscape(v?.source ?? '(unknown)');
+    violations.push({
+      label:
+        `[OG ${mdEscape(v?.kind ?? '')}] ${mdEscape(v?.field ?? '')}`.trim(),
+      detail: `At: ${location} — expected: ${mdEscape(v?.expected ?? '')} · actual: ${mdEscape(v?.actual ?? '')}`,
+    });
+  }
+  for (const v of rssViolations) {
+    const location = mdEscape(v?.source ?? '(unknown)');
+    violations.push({
+      label:
+        `[RSS ${mdEscape(v?.kind ?? '')}] ${mdEscape(v?.field ?? '')}`.trim(),
+      detail: `At: ${location} — expected: ${mdEscape(v?.expected ?? '')} · actual: ${mdEscape(v?.actual ?? '')}`,
+    });
+  }
+
+  return {
+    kind: 'fail',
+    counts,
+    violations,
+    summary: `${ogViolations.length} OG + ${rssViolations.length} RSS violation(s)`,
+  };
+}
+
+// --- Report loading --------------------------------------------------
+
+/**
+ * Attempt to read + parse a component's JSON report. Returns:
+ *   - parsed object if the file exists and parses;
+ *   - `null` if the file does NOT exist (treated as "not run" by
+ *     classifiers that want to distinguish this case);
+ *   - `{ __parse_error: message }` if the file exists but is malformed.
+ *
+ * Never throws — the aggregator is a reporter, not a gate.
+ */
+export function loadReport(reportDir, filename) {
+  if (filename === null) return null;
+  const path = join(reportDir, filename);
+  if (!existsSync(path)) return null;
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (err) {
+    return { __parse_error: `Cannot read ${path}: ${err.code || err.message}` };
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    return { __parse_error: `Invalid JSON in ${path}: ${err.message}` };
+  }
+}
+
+/**
+ * Drive a single component through read → classify. Returns `{id,
+ * title, report_file, status}` for downstream rendering. Parse errors
+ * short-circuit to a `parse_error` status without invoking the
+ * component's classifier.
+ */
+export function evaluateComponent(component, reportDir) {
+  const json = loadReport(reportDir, component.report_file);
+
+  if (json && json.__parse_error) {
+    return {
+      id: component.id,
+      title: component.title,
+      report_file: component.report_file,
+      status: {
+        kind: 'parse_error',
+        note: json.__parse_error,
+      },
+    };
+  }
+
+  if (json === null && component.id !== 'QA-10.4') {
+    return {
+      id: component.id,
+      title: component.title,
+      report_file: component.report_file,
+      status: {
+        kind: 'not_run',
+        note:
+          'Per-run JSON report not found — component did not run to completion, ' +
+          'or its CI step was skipped due to an earlier failure.',
+      },
+    };
+  }
+
+  return {
+    id: component.id,
+    title: component.title,
+    report_file: component.report_file,
+    status: component.classifier(json),
+  };
+}
+
+// --- Rendering -------------------------------------------------------
+
+/**
+ * Format a counts record as a Markdown badge-like row. Empty record
+ * returns `''` so callers can concatenate unconditionally.
+ */
+function renderCounts(counts) {
+  if (!counts || Object.keys(counts).length === 0) return '';
+  const parts = [];
+  for (const [key, value] of Object.entries(counts)) {
+    parts.push(`**${key}**: ${value}`);
+  }
+  return parts.join(' | ');
+}
+
+/**
+ * Render a single component section as Markdown. Kept as an exported
+ * pure function so unit tests drive the renderer with fixtures instead
+ * of the filesystem.
+ */
+export function renderComponentSection(evaluation) {
+  const { id, title, report_file, status } = evaluation;
+  const icon = STATUS_ICON[status.kind];
+  const label = STATUS_LABEL[status.kind];
+  const lines = [];
+
+  lines.push(`### ${icon} ${id} — ${title} — ${label}`);
+  lines.push('');
+
+  if (status.summary) {
+    lines.push(status.summary);
+    lines.push('');
+  }
+
+  const countsLine = renderCounts(status.counts);
+  if (countsLine !== '') {
+    lines.push(countsLine);
+    lines.push('');
+  }
+
+  if (status.note) {
+    lines.push(status.note);
+    lines.push('');
+  }
+
+  if (Array.isArray(status.violations) && status.violations.length > 0) {
+    lines.push('**Violations**:');
+    lines.push('');
+    for (const v of status.violations) {
+      lines.push(`- **${v.label}**`);
+      if (v.detail) {
+        lines.push(`  - ${v.detail}`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Cross-link to the raw JSON artifact for deep inspection (AC bullet
+  // 6). Omitted for statuses where no JSON file exists to fetch:
+  //   - `inline` (QA-10.4): the inline note already names the relevant
+  //     artifacts (sidecar baselines + QA-09 CI step).
+  //   - `not_run`: the component's CI step was skipped (typically due
+  //     to an earlier failure), so no JSON was written — the pointer
+  //     would send reviewers to a file that isn't in the artifact.
+  // Parse errors keep the link because the JSON file exists (just
+  // malformed) and the reviewer may want to fetch it to debug.
+  const hasJson =
+    status.kind === 'pass' ||
+    status.kind === 'fail' ||
+    status.kind === 'parse_error';
+  if (hasJson && report_file) {
+    lines.push(
+      `<sub>Raw report: \`${report_file}\` in the \`${JSON_ARTIFACT_NAME}\` CI artifact (uploaded on failure).</sub>`,
+    );
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Overall aggregator verdict. `fail` dominates (any component fail →
+ * overall fail); `parse_error` also counts as fail (we can't confirm
+ * pass). `not_run` is reported but does NOT mark overall fail —
+ * skipped-step aggregation is expected on the CI failure-then-skip
+ * path. `inline` is treated as informational (cannot aggregate a pass
+ * verdict from an empty classifier).
+ */
+export function computeOverall(evaluations) {
+  let failed = 0;
+  let parseErrors = 0;
+  let notRun = 0;
+  let passed = 0;
+  let inline = 0;
+  for (const e of evaluations) {
+    switch (e.status.kind) {
+      case 'fail':
+        failed += 1;
+        break;
+      case 'parse_error':
+        parseErrors += 1;
+        break;
+      case 'not_run':
+        notRun += 1;
+        break;
+      case 'pass':
+        passed += 1;
+        break;
+      case 'inline':
+        inline += 1;
+        break;
+    }
+  }
+
+  const totalGating = failed + parseErrors + passed;
+  // "All passing" requires every gating component to have produced a
+  // confirming pass — zero failures, zero parse errors, zero not-run,
+  // and at least one component actually ran. Inline-only (QA-10.4) is
+  // not a pass signal on its own; not-run implies an upstream skip
+  // (typically a prior step's failure on the `failure → skip` CI path)
+  // which by definition means we cannot confirm overall pass.
+  const allPassing =
+    failed === 0 && parseErrors === 0 && notRun === 0 && passed > 0;
+
+  return {
+    allPassing,
+    failed,
+    parseErrors,
+    notRun,
+    passed,
+    inline,
+    totalGating,
+    total: evaluations.length,
+  };
+}
+
+/**
+ * Render the aggregated report. On 100% component pass (overall),
+ * collapses to the single-line positive summary per AC. On any
+ * failure (including parse errors), renders full per-component
+ * sections with violation detail expanded.
+ */
+export function renderReport(evaluations, { runIso } = {}) {
+  const overall = computeOverall(evaluations);
+  const lines = [COMMENT_MARKER, '', '# QA-10 aggregated audit report', ''];
+  lines.push(`**Run**: ${runIso ?? new Date().toISOString()}`);
+  lines.push('');
+
+  if (overall.allPassing) {
+    // One-line positive summary (AC bullet 5). `allPassing` (defined
+    // in computeOverall) already requires zero failures, zero parse
+    // errors, zero not-run components, and at least one confirmed
+    // pass — no further conjuncts needed here. Components are listed
+    // compactly so reviewers still see each one was accounted for.
+    const per = evaluations
+      .map((e) => `${STATUS_ICON[e.status.kind]} ${e.id}`)
+      .join(' · ');
+    lines.push(`✅ **All QA-10 checks passed.** ${per}`);
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  // Failure / mixed state: full detail expanded.
+  const headline = [];
+  if (overall.failed > 0) headline.push(`${overall.failed} failed`);
+  if (overall.parseErrors > 0) {
+    headline.push(`${overall.parseErrors} parse error(s)`);
+  }
+  if (overall.notRun > 0) headline.push(`${overall.notRun} not run`);
+  if (overall.passed > 0) headline.push(`${overall.passed} passed`);
+  if (overall.inline > 0) headline.push(`${overall.inline} inline`);
+  const headlineStr =
+    headline.length > 0 ? headline.join(', ') : 'no components';
+  lines.push(
+    `❌ **QA-10 status** — ${headlineStr} (of ${overall.total} total).`,
+  );
+  lines.push('');
+
+  // Quick-look status table so reviewers scan status first, detail
+  // second. Duplicates the per-section headers intentionally — the
+  // table works in email previews that truncate after the first few
+  // kilobytes, and the sections work when the reviewer lands on GitHub.
+  lines.push('| Component | Status | Summary |');
+  lines.push('| --- | --- | --- |');
+  for (const e of evaluations) {
+    const icon = STATUS_ICON[e.status.kind];
+    const label = STATUS_LABEL[e.status.kind];
+    const summary = e.status.summary ?? e.status.note ?? '';
+    const truncated =
+      summary.length > 120 ? summary.slice(0, 117) + '...' : summary;
+    lines.push(`| ${e.id} — ${e.title} | ${icon} ${label} | ${truncated} |`);
+  }
+  lines.push('');
+
+  lines.push('## Per-component detail');
+  lines.push('');
+  for (const e of evaluations) {
+    lines.push(renderComponentSection(e));
+  }
+
+  return lines.join('\n');
+}
+
+// --- CLI -------------------------------------------------------------
+
+/**
+ * CLI entry point. Reads every component's JSON from the canonical
+ * report directory, renders the aggregated Markdown, and writes it to
+ * disk. Exits 0 unconditionally — CI gating is the caller's
+ * responsibility (this script reports; it does not gate).
+ */
+export function main() {
+  const evaluations = COMPONENTS.map((c) => evaluateComponent(c, REPORT_DIR));
+  const markdown = renderReport(evaluations);
+  mkdirSync(REPORT_DIR, { recursive: true });
+  writeFileSync(OUTPUT_PATH, markdown + '\n', 'utf8');
+
+  // Echo to stdout so the CI log surfaces the same content reviewers
+  // see in the PR comment, in case the comment posting step is
+  // skipped (non-PR event, missing permission, etc.).
+  process.stdout.write(markdown + '\n');
+  process.stdout.write(
+    `\nAggregated report: ${relative(REPO_ROOT, OUTPUT_PATH)}\n`,
+  );
+}
+
+const isCli = process.argv[1] === fileURLToPath(import.meta.url);
+if (isCli) {
+  try {
+    main();
+  } catch (err) {
+    // Defensive — any uncaught error inside the aggregator is a bug,
+    // not an audit finding. Surface loudly rather than silently failing
+    // (which would leave the CI artifact + PR comment stale).
+    process.stderr.write(`[audit-report] ERROR: ${err.stack || err.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/audit-report.test.mjs
+++ b/scripts/audit-report.test.mjs
@@ -1,0 +1,661 @@
+// Unit tests for scripts/audit-report.mjs (QA-10 aggregated audit
+// report). Exercises every classifier against pass/fail fixtures, the
+// overall computation across mixed states, and the rendering contract
+// (one-line positive on all-pass, full detail expanded on failure).
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  COMMENT_MARKER,
+  JSON_ARTIFACT_NAME,
+  mdEscape,
+  classifyRoutes,
+  classifyWidths,
+  classifyInvariants,
+  classifyCrossSections,
+  classifyOgRss,
+  evaluateComponent,
+  loadReport,
+  computeOverall,
+  renderReport,
+  renderComponentSection,
+} from './audit-report.mjs';
+
+describe('mdEscape', () => {
+  it('returns empty string for null / undefined', () => {
+    expect(mdEscape(null)).toBe('');
+    expect(mdEscape(undefined)).toBe('');
+  });
+
+  it('stringifies other non-string input without escaping', () => {
+    // Non-string inputs are stringified via `String(value ?? '')` and do
+    // NOT run through the escape pipeline — the only callers passing
+    // non-strings are numeric labels (viewports, thresholds) which never
+    // contain markdown-corrupting characters.
+    expect(mdEscape(42)).toBe('42');
+  });
+
+  it('passes plain strings through', () => {
+    expect(mdEscape('hello world')).toBe('hello world');
+    expect(mdEscape('/blog/sample-post/')).toBe('/blog/sample-post/');
+  });
+
+  it('escapes backticks', () => {
+    expect(mdEscape('use `foo` here')).toBe('use \\`foo\\` here');
+  });
+
+  it('escapes pipes', () => {
+    expect(mdEscape('a|b|c')).toBe('a\\|b\\|c');
+  });
+
+  it('entity-encodes angle brackets', () => {
+    expect(mdEscape('<meta>')).toBe('&lt;meta&gt;');
+  });
+
+  it('escapes backslashes first so escape sequences do not collide', () => {
+    expect(mdEscape('path\\to')).toBe('path\\\\to');
+  });
+});
+
+describe('classifyRoutes', () => {
+  it('returns pass when no unregistered or drift routes', () => {
+    const status = classifyRoutes({
+      results: [
+        { route: '/', matches: true },
+        { route: '/blog/', matches: true },
+      ],
+      unregistered_routes: [],
+      drift_routes: [],
+    });
+    expect(status.kind).toBe('pass');
+    expect(status.counts).toEqual({
+      total: 2,
+      matched: 2,
+      unregistered: 0,
+      drift: 0,
+    });
+  });
+
+  it('returns fail with violations for unregistered routes', () => {
+    const status = classifyRoutes({
+      results: [
+        { route: '/new', matches: false },
+        { route: '/', matches: true },
+      ],
+      unregistered_routes: ['/new'],
+      drift_routes: [],
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.counts.unregistered).toBe(1);
+    expect(status.violations).toHaveLength(1);
+    expect(status.violations[0].label).toContain('/new');
+  });
+
+  it('returns fail with violations for drift routes', () => {
+    const status = classifyRoutes({
+      results: [{ route: '/a', matches: false }],
+      unregistered_routes: [],
+      drift_routes: [
+        { route: '/a', registered_as: 'home', matches_archetype: 'blog' },
+      ],
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.counts.drift).toBe(1);
+    expect(status.violations[0].label).toContain('/a');
+    expect(status.violations[0].detail).toContain('home');
+    expect(status.violations[0].detail).toContain('blog');
+  });
+
+  it('tolerates missing arrays', () => {
+    const status = classifyRoutes({});
+    expect(status.kind).toBe('pass');
+    expect(status.counts.total).toBe(0);
+  });
+});
+
+describe('classifyWidths', () => {
+  it('returns pass when no unhandled or expired thresholds', () => {
+    const status = classifyWidths({
+      counts: { covered: 8, allowlisted: 2, expired: 0, unhandled: 0 },
+      thresholds: [],
+    });
+    expect(status.kind).toBe('pass');
+    expect(status.counts.covered).toBe(8);
+  });
+
+  it('returns fail when unhandled thresholds exist', () => {
+    const status = classifyWidths({
+      counts: { covered: 4, allowlisted: 0, expired: 0, unhandled: 1 },
+      thresholds: [
+        {
+          threshold_px: 851,
+          classification: 'unhandled',
+          features: ['min-width'],
+          sources: [{ source_file: 'dist/_astro/x.css' }],
+        },
+      ],
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations).toHaveLength(1);
+    expect(status.violations[0].label).toContain('851');
+    expect(status.violations[0].detail).toContain('dist/_astro/x.css');
+  });
+
+  it('returns fail when expired allowlist entries exist', () => {
+    const status = classifyWidths({
+      counts: { covered: 4, allowlisted: 0, expired: 1, unhandled: 0 },
+      thresholds: [
+        {
+          threshold_px: 639,
+          classification: 'expired',
+          features: ['max-width'],
+          sources: [{ source_file: 'dist/_astro/y.css' }],
+        },
+      ],
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations[0].label).toContain('expired');
+  });
+
+  it('tolerates missing counts object', () => {
+    const status = classifyWidths({ thresholds: [] });
+    expect(status.kind).toBe('pass');
+  });
+});
+
+describe('classifyInvariants', () => {
+  it('returns pass when all invariants hold', () => {
+    const status = classifyInvariants({
+      invariants: [
+        { id: 'inv-1', title: 'T1', pass: true, runs: [] },
+        { id: 'inv-2', title: 'T2', pass: true, runs: [] },
+      ],
+    });
+    expect(status.kind).toBe('pass');
+    expect(status.counts.passing).toBe(2);
+    expect(status.counts.failing).toBe(0);
+  });
+
+  it('returns fail with per-run detail on failure', () => {
+    const status = classifyInvariants({
+      invariants: [
+        {
+          id: 'inv-4',
+          title: 'nav overlap',
+          pass: false,
+          runs: [
+            { viewport: '480', mode: 'light', pass: false },
+            { viewport: '768', mode: 'light', pass: true },
+          ],
+        },
+      ],
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations).toHaveLength(1);
+    expect(status.violations[0].label).toContain('inv-4');
+    expect(status.violations[0].detail).toContain('480px');
+  });
+
+  it('tolerates missing runs field', () => {
+    const status = classifyInvariants({
+      invariants: [{ id: 'inv-x', title: 'T', pass: false }],
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations[0].detail).toContain('no per-run detail');
+  });
+});
+
+describe('classifyCrossSections', () => {
+  it('returns inline status when no JSON file exists', () => {
+    const status = classifyCrossSections(null);
+    expect(status.kind).toBe('inline');
+    expect(status.note).toContain('QA-09');
+    expect(status.note).toContain('tests/visual/__baselines__');
+  });
+
+  it('returns pass when future JSON exists with zero violations', () => {
+    const status = classifyCrossSections({ checked: 72, violations: [] });
+    expect(status.kind).toBe('pass');
+    expect(status.counts.checked).toBe(72);
+  });
+
+  it('returns fail when future JSON carries violations', () => {
+    const status = classifyCrossSections({
+      checked: 72,
+      violations: [{ label: '.site-nav drift', detail: 'color shifted' }],
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations[0].label).toContain('.site-nav');
+  });
+});
+
+describe('classifyOgRss', () => {
+  it('returns pass when OG and RSS both clean', () => {
+    const status = classifyOgRss({
+      html_pages_scanned: 5,
+      blog_post_pages: 1,
+      rss_items: 1,
+      og: { violations: [], per_page: [] },
+      rss: { violations: [], channel_present: true, item_count: 1 },
+    });
+    expect(status.kind).toBe('pass');
+  });
+
+  it('returns fail when OG side has violations', () => {
+    const status = classifyOgRss({
+      html_pages_scanned: 5,
+      og: {
+        violations: [
+          {
+            kind: 'og_title_mismatch',
+            field: 'og:title',
+            page: 'dist/blog/foo/index.html',
+            url: '/blog/foo/',
+            expected: 'X',
+            actual: 'Y',
+          },
+        ],
+      },
+      rss: { violations: [] },
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations[0].label).toContain('OG');
+    expect(status.violations[0].detail).toContain('X');
+    expect(status.violations[0].detail).toContain('Y');
+  });
+
+  it('returns fail when RSS side has violations', () => {
+    const status = classifyOgRss({
+      og: { violations: [] },
+      rss: {
+        violations: [
+          {
+            kind: 'rss_missing_field',
+            field: 'item[0] > title',
+            source: 'dist/rss.xml',
+            expected: 'present',
+            actual: 'missing',
+          },
+        ],
+      },
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations[0].label).toContain('RSS');
+  });
+
+  it('interleaves OG + RSS violations in one list', () => {
+    const status = classifyOgRss({
+      og: {
+        violations: [
+          {
+            kind: 'og_title_mismatch',
+            field: 'og:title',
+            page: 'p',
+            url: '/u/',
+          },
+        ],
+      },
+      rss: {
+        violations: [
+          {
+            kind: 'rss_missing_field',
+            field: 'item[0] > link',
+            source: 'dist/rss.xml',
+          },
+        ],
+      },
+    });
+    expect(status.kind).toBe('fail');
+    expect(status.violations).toHaveLength(2);
+  });
+});
+
+describe('loadReport', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'audit-report-test-'));
+
+  it('returns null when the file is missing', () => {
+    expect(loadReport(tmp, 'missing.json')).toBeNull();
+  });
+
+  it('returns null when filename is null (QA-10.4)', () => {
+    expect(loadReport(tmp, null)).toBeNull();
+  });
+
+  it('returns parsed JSON when the file exists and is valid', () => {
+    const path = join(tmp, 'valid.json');
+    writeFileSync(path, JSON.stringify({ a: 1, b: 'hello' }));
+    expect(loadReport(tmp, 'valid.json')).toEqual({ a: 1, b: 'hello' });
+  });
+
+  it('returns a parse_error marker when JSON is malformed', () => {
+    const path = join(tmp, 'bad.json');
+    writeFileSync(path, '{not json');
+    const result = loadReport(tmp, 'bad.json');
+    expect(result).toHaveProperty('__parse_error');
+    expect(result.__parse_error).toContain('bad.json');
+  });
+});
+
+describe('evaluateComponent', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'audit-report-eval-'));
+
+  it('short-circuits to parse_error when JSON is malformed', () => {
+    writeFileSync(join(tmp, 'routes-report.json'), '{not json');
+    const out = evaluateComponent(
+      {
+        id: 'QA-10.1',
+        title: 'Route clustering',
+        report_file: 'routes-report.json',
+        classifier: classifyRoutes,
+      },
+      tmp,
+    );
+    expect(out.status.kind).toBe('parse_error');
+    expect(out.status.note).toContain('Invalid JSON');
+  });
+
+  it('returns not_run when JSON is missing (non-QA-10.4)', () => {
+    const out = evaluateComponent(
+      {
+        id: 'QA-10.2',
+        title: 'Critical widths',
+        report_file: 'widths-report.json',
+        classifier: classifyWidths,
+      },
+      mkdtempSync(join(tmpdir(), 'audit-report-missing-')),
+    );
+    expect(out.status.kind).toBe('not_run');
+  });
+
+  it('returns inline for QA-10.4 when JSON is missing', () => {
+    const out = evaluateComponent(
+      {
+        id: 'QA-10.4',
+        title: 'DOM cross-sections',
+        report_file: 'cross-sections-report.json',
+        classifier: classifyCrossSections,
+      },
+      mkdtempSync(join(tmpdir(), 'audit-report-inline-')),
+    );
+    expect(out.status.kind).toBe('inline');
+  });
+
+  it('delegates to classifier when JSON is present', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'audit-report-pass-'));
+    writeFileSync(
+      join(dir, 'widths-report.json'),
+      JSON.stringify({
+        counts: { covered: 5, allowlisted: 0, expired: 0, unhandled: 0 },
+        thresholds: [],
+      }),
+    );
+    const out = evaluateComponent(
+      {
+        id: 'QA-10.2',
+        title: 'Critical widths',
+        report_file: 'widths-report.json',
+        classifier: classifyWidths,
+      },
+      dir,
+    );
+    expect(out.status.kind).toBe('pass');
+  });
+});
+
+describe('computeOverall', () => {
+  it('marks all passing when every gating component passes', () => {
+    const evaluations = [
+      { status: { kind: 'pass' } },
+      { status: { kind: 'pass' } },
+      { status: { kind: 'inline' } },
+    ];
+    const o = computeOverall(evaluations);
+    expect(o.allPassing).toBe(true);
+    expect(o.failed).toBe(0);
+    expect(o.passed).toBe(2);
+    expect(o.inline).toBe(1);
+  });
+
+  it('marks not-all-passing when any fail', () => {
+    const evaluations = [
+      { status: { kind: 'pass' } },
+      { status: { kind: 'fail' } },
+    ];
+    const o = computeOverall(evaluations);
+    expect(o.allPassing).toBe(false);
+    expect(o.failed).toBe(1);
+  });
+
+  it('marks not-all-passing on parse errors', () => {
+    const evaluations = [
+      { status: { kind: 'pass' } },
+      { status: { kind: 'parse_error' } },
+    ];
+    const o = computeOverall(evaluations);
+    expect(o.allPassing).toBe(false);
+    expect(o.parseErrors).toBe(1);
+  });
+
+  it('inline-only runs are NOT all passing (no confirming pass)', () => {
+    const evaluations = [{ status: { kind: 'inline' } }];
+    const o = computeOverall(evaluations);
+    expect(o.allPassing).toBe(false);
+  });
+
+  it('not_run is reported and blocks the one-line positive summary', () => {
+    const evaluations = [
+      { status: { kind: 'pass' } },
+      { status: { kind: 'not_run' } },
+    ];
+    const o = computeOverall(evaluations);
+    // Not-run is NOT a new failure count — the failure that caused the
+    // skip is reported on its own failing step — but it blocks
+    // allPassing because we cannot confirm the skipped component
+    // would have passed. The aggregated comment therefore expands full
+    // detail, which surfaces the not-run components visibly.
+    expect(o.failed).toBe(0);
+    expect(o.parseErrors).toBe(0);
+    expect(o.notRun).toBe(1);
+    expect(o.allPassing).toBe(false);
+  });
+});
+
+describe('renderReport', () => {
+  const runIso = '2026-04-23T12:00:00.000Z';
+
+  it('emits COMMENT_MARKER as the first line', () => {
+    const md = renderReport(
+      [{ id: 'QA-10.1', title: 'T', status: { kind: 'pass' } }],
+      { runIso },
+    );
+    expect(md.split('\n')[0]).toBe(COMMENT_MARKER);
+  });
+
+  it('collapses to one-line summary on all-pass', () => {
+    const evaluations = [
+      {
+        id: 'QA-10.1',
+        title: 'Route clustering',
+        status: { kind: 'pass', summary: 's' },
+      },
+      {
+        id: 'QA-10.2',
+        title: 'Critical widths',
+        status: { kind: 'pass', summary: 's' },
+      },
+      {
+        id: 'QA-10.4',
+        title: 'DOM cross-sections',
+        status: { kind: 'inline' },
+      },
+    ];
+    const md = renderReport(evaluations, { runIso });
+    expect(md).toContain('All QA-10 checks passed');
+    // No per-component detail headers on all-pass.
+    expect(md).not.toContain('## Per-component detail');
+  });
+
+  it('expands full per-component detail on any failure', () => {
+    const evaluations = [
+      {
+        id: 'QA-10.1',
+        title: 'Route clustering',
+        report_file: 'routes-report.json',
+        status: {
+          kind: 'fail',
+          counts: { total: 3, matched: 2, unregistered: 1, drift: 0 },
+          violations: [{ label: '/new', detail: 'No archetype.' }],
+          summary: '1 unregistered',
+        },
+      },
+      {
+        id: 'QA-10.2',
+        title: 'Critical widths',
+        report_file: 'widths-report.json',
+        status: {
+          kind: 'pass',
+          counts: { covered: 5, allowlisted: 0, expired: 0, unhandled: 0 },
+          summary: 'clean',
+        },
+      },
+    ];
+    const md = renderReport(evaluations, { runIso });
+    expect(md).toContain('❌');
+    expect(md).toContain('| Component | Status | Summary |');
+    expect(md).toContain('## Per-component detail');
+    expect(md).toContain('QA-10.1');
+    expect(md).toContain('/new');
+    expect(md).toContain('No archetype');
+    expect(md).toContain(JSON_ARTIFACT_NAME);
+  });
+
+  it('reports parse errors as failures in the headline', () => {
+    const evaluations = [
+      {
+        id: 'QA-10.1',
+        title: 'T',
+        report_file: 'routes-report.json',
+        status: { kind: 'parse_error', note: 'bad JSON' },
+      },
+    ];
+    const md = renderReport(evaluations, { runIso });
+    expect(md).toContain('parse error');
+    expect(md).toContain('bad JSON');
+  });
+});
+
+describe('renderComponentSection', () => {
+  it('renders the raw-report pointer on non-inline statuses', () => {
+    const md = renderComponentSection({
+      id: 'QA-10.1',
+      title: 'Route clustering',
+      report_file: 'routes-report.json',
+      status: {
+        kind: 'pass',
+        counts: { total: 1, matched: 1 },
+        summary: 'ok',
+      },
+    });
+    expect(md).toContain('routes-report.json');
+    expect(md).toContain(JSON_ARTIFACT_NAME);
+  });
+
+  it('omits the raw-report pointer on inline statuses', () => {
+    const md = renderComponentSection({
+      id: 'QA-10.4',
+      title: 'DOM cross-sections',
+      report_file: 'cross-sections-report.json',
+      status: {
+        kind: 'inline',
+        note: 'runs inline in QA-09',
+      },
+    });
+    expect(md).toContain('runs inline in QA-09');
+    expect(md).not.toContain(JSON_ARTIFACT_NAME);
+  });
+
+  it('omits the raw-report pointer on not_run statuses (no JSON was written)', () => {
+    const md = renderComponentSection({
+      id: 'QA-10.3',
+      title: 'Invariant specs',
+      report_file: 'invariants-report.json',
+      status: {
+        kind: 'not_run',
+        note: 'component skipped due to prior failure',
+      },
+    });
+    expect(md).toContain('component skipped');
+    // The pointer promises a file in the artifact, but not_run means
+    // no JSON was produced — sending reviewers there would mislead.
+    expect(md).not.toContain(JSON_ARTIFACT_NAME);
+  });
+
+  it('keeps the raw-report pointer on parse_error statuses (JSON exists, just malformed)', () => {
+    const md = renderComponentSection({
+      id: 'QA-10.1',
+      title: 'Route clustering',
+      report_file: 'routes-report.json',
+      status: {
+        kind: 'parse_error',
+        note: 'Invalid JSON at offset 5',
+      },
+    });
+    // The JSON file exists on disk but was malformed; the reviewer
+    // needs to download it to debug the parse failure.
+    expect(md).toContain(JSON_ARTIFACT_NAME);
+    expect(md).toContain('routes-report.json');
+  });
+
+  it('escapes backticks in violation content so embedded code spans do not corrupt rendering', () => {
+    const status = classifyOgRss({
+      og: {
+        violations: [
+          {
+            kind: 'og_title_mismatch',
+            field: 'og:title',
+            page: 'p',
+            url: '/u/',
+            expected: 'Title with `backtick`',
+            actual: 'Actual',
+          },
+        ],
+      },
+      rss: { violations: [] },
+    });
+    const md = renderComponentSection({
+      id: 'QA-10.5',
+      title: 'OG',
+      report_file: 'og-rss-report.json',
+      status,
+    });
+    // The backtick must be escaped (not left raw) to avoid opening
+    // an unpaired code span that swallows subsequent text.
+    expect(md).toContain('\\`backtick\\`');
+    expect(md).not.toContain('Title with `backtick`');
+  });
+
+  it('renders violation label + detail indented under it', () => {
+    const md = renderComponentSection({
+      id: 'QA-10.3',
+      title: 'Invariants',
+      report_file: 'invariants-report.json',
+      status: {
+        kind: 'fail',
+        counts: { total: 2, passing: 1, failing: 1 },
+        violations: [
+          {
+            label: 'invariant-4: nav overlap',
+            detail: 'Failed at: 480px light',
+          },
+        ],
+        summary: '1 of 2 violated',
+      },
+    });
+    expect(md).toContain('**Violations**:');
+    expect(md).toContain('- **invariant-4: nav overlap**');
+    expect(md).toContain('  - Failed at: 480px light');
+  });
+});


### PR DESCRIPTION
Closes #131.

## Summary

Aggregates per-component JSON outputs from QA-10.1 / 10.2 / 10.3 / 10.5 into a single consolidated Markdown document. Uploaded as CI artifact `qa-10-audit-report`, and posted/updated as a single stable PR comment via `peter-evans/find-comment@v3` + `peter-evans/create-or-update-comment@v4` (marker: `<!-- qa-10-audit-report -->`).

On 100% pass → one-line positive summary. On any failure → full per-component detail expanded, with the raw JSON cross-linked to the existing `qa-10-audit-reports` artifact.

## Files

| Path | Change |
| --- | --- |
| `scripts/audit-report.mjs` | New — pure-Node aggregator + classifiers + renderers |
| `scripts/audit-report.test.mjs` | New — 47 vitest unit tests (pass/fail/edge for every classifier, rendering contract, Markdown escaping) |
| `.github/workflows/ci.yml` | New aggregator / artifact / find-comment / create-or-update-comment steps, plus job-level `pull-requests: write` permission |

## AC verification

| # | AC | Status |
| --- | --- | --- |
| 1 | Create `scripts/audit-report.mjs` reading `tests/audit/__reports__/*.json` → `audit-report.md` | ✅ |
| 2 | One section per component (QA-10.1..10.5) with status / counts / violations from each JSON | ✅ — graceful degradation for QA-10.4 (see caveat below) |
| 3 | Upload `audit-report.md` as CI artifact after audit steps regardless of pass/fail | ✅ (`if: ${{ !cancelled() }}`) |
| 4 | Post as PR comment via `peter-evans/create-or-update-comment@v4`, updating (not appending) on re-runs | ✅ (marker-based upsert) |
| 5 | 100% pass → single-line; any failure → full detail expanded | ✅ (tested both branches) |
| 6 | Cross-link per-component details to JSON artifact | ✅ (on every `pass`/`fail`/`parse_error` section) |
| 7 | Full interactive HTML report OUT OF SCOPE | ✅ (not implemented) |
| 8 | Extend `test:audit` meta-script to include `og-rss` when QA-10.5 lands | ✅ (already landed via #133) |

## QA-10.4 caveat (graceful degradation)

QA-10.4 does not emit a per-run JSON report to `tests/audit/__reports__/` — its artifacts are `.styles.json` sidecar baselines at `tests/visual/__baselines__/` and its checks happen inline inside the `QA-07 / QA-08 / QA-09 — Playwright suites` step (via `reconcileSidecar` in `tests/visual/screenshots.spec.ts`). The aggregator handles this with an `inline` status that renders a note pointing reviewers at the Playwright step and the sidecar baselines.

If a future iteration adds `cross-sections-report.json` to `tests/audit/__reports__/` (e.g., summarizing sidecar reconciliation at run-level), the classifier at `scripts/audit-report.mjs` `classifyCrossSections` picks it up automatically — no aggregator change needed. Out of scope for this PR; flagged here for the Wave 2 operator's awareness.

## Caller context observation

The Wave 2 convergence brief stated "per-component JSON outputs from QA-10.1..10.5 are now produced by existing CI steps and available at `tests/audit/__reports__/*.json`". This holds for QA-10.1 / 10.2 / 10.3 / 10.5 but not QA-10.4 (see caveat above). The aggregator's graceful degradation absorbs the difference and does not block Wave 2 closure.

## Quality gates

- `npm run test` → **164 tests passed** (7 files), 47 new in `audit-report.test.mjs`
- `npm run lint` → 0 errors, 0 warnings
- `npm run typecheck` → 0 errors, 0 warnings (2 pre-existing unrelated hints)
- `npm run format:check` → new files prettier-clean
- Independent fresh-context validate subprocess → **CLEAN** (5 P2 findings, all addressed in-thread before commit: `mdEscape` helper, cross-link gating on `not_run`, docblock precision, redundant guard removal, expanded test coverage)
- Independent fresh-context polish subprocess → **CLEAN** (one test split applied; other candidates rejected with documented reasons)

## Test plan

- [x] Unit tests pass locally (`npm run test`)
- [ ] CI: every audit step runs and the aggregator renders the expected mixed-state table (this PR carries no audit regressions so expect `✅ All QA-10 checks passed` as the one-line comment)
- [ ] CI: `qa-10-audit-report` artifact appears on Actions run
- [ ] CI: a single `<!-- qa-10-audit-report -->` comment appears on this PR
- [ ] CI re-run: comment is UPDATED in place (not duplicated)
- [ ] Automated reviewer (Copilot) feedback addressed

## Future consideration (not blocking)

Forked PRs receive a read-only `GITHUB_TOKEN`, so `peter-evans/create-or-update-comment` would fail on external contributor PRs. For a primarily solo/orchestrated repo today, this is a future concern. If / when external contribution starts, either add `pull_request_target` fallback or accept that fork PRs won't get the comment (the artifact will still upload on the base-repo side).

---

References:
- PDR-007 § Decision Phase 2, § 6 Item 13 (HQ repo, private — see `CONTRIBUTING.md` § Cross-repo setup)
- `audit-tooling-design.md` § 6 Item 13