### PR TITLE
(feat) add chapter + wwh taxonomy constants per PDR-009 (#164)

### DIFF
--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -1,9 +1,16 @@
 /**
- * Single source of truth for content taxonomy (pillars and series).
+ * Single source of truth for content taxonomy.
+ *
+ * Covers two layers:
+ * - Pillars and series (blog front-matter `pillar`/`series` fields).
+ * - Namespaced tag conventions `chapter:*` and `wwh:*` adopted by PDR-009
+ *   (HDIAI HQ `docs/decisions/PDR-009-schema-evolution-principle.md`).
+ *   Values mirror HQ `content/strategy.md` § Reserved Tag Namespaces.
  *
  * All consumers — Zod schema, badge components, nav, client-side filter,
- * post type aliases — must import from this module rather than defining
- * their own copy. Adding or renaming a pillar/series happens here, once.
+ * post type aliases, JSON-LD emission, llms.txt — must import from this
+ * module rather than defining their own copy. Adding or renaming a
+ * pillar/series/chapter/wwh happens here, once.
  */
 
 export const PILLARS = {
@@ -31,3 +38,37 @@ export const SERIES_SLUGS = Object.keys(SERIES) as [
   SeriesSlug,
   ...SeriesSlug[],
 ];
+
+export const CHAPTER_SLUGS = [
+  'first-moves',
+  'mental-models',
+  'interaction',
+  'judgment',
+  'workflow',
+  'where-you-are',
+  'meta-skill',
+] as const;
+
+export const WWH_SLUGS = [
+  'what-works',
+  'when-to-use',
+  'how-to-do',
+  'meta-outside',
+] as const;
+
+export const CHAPTER_LABELS: Record<(typeof CHAPTER_SLUGS)[number], string> = {
+  'first-moves': 'First Moves',
+  'mental-models': 'Mental Models',
+  interaction: 'Interaction',
+  judgment: 'Judgment',
+  workflow: 'Workflow',
+  'where-you-are': 'Where You Are',
+  'meta-skill': 'Meta-skill',
+};
+
+export const WWH_LABELS: Record<(typeof WWH_SLUGS)[number], string> = {
+  'what-works': 'What works?',
+  'when-to-use': 'When to use?',
+  'how-to-do': 'How to do?',
+  'meta-outside': 'Meta',
+};


### PR DESCRIPTION
## Summary

- Extend `src/lib/taxonomy.ts` with four new exports (`CHAPTER_SLUGS`, `WWH_SLUGS`, `CHAPTER_LABELS`, `WWH_LABELS`) per PDR-009 § 4 reference implementation.
- Values mirror HQ `content/strategy.md` § Reserved Tag Namespaces (cross-repo SSoT, established by `how-do-i-ai/hq#28`).
- Existing `PILLARS`, `SERIES`, `PILLAR_SLUGS`, `SERIES_SLUGS` untouched — content.config.ts consumers unaffected.

## Context

This is the shared taxonomy foundation that unblocks the PDR-009 schema work chain:

- #165 (W-G) — `content.config.ts` `superRefine` validation using `CHAPTER_SLUGS`, `WWH_SLUGS`
- #166 (W-H) — post-card / header badges using `CHAPTER_LABELS`, `WWH_LABELS`
- #167 (W-I) — BlogFilter chip labels resolving `chapter:*` / `wwh:*` via taxonomy labels
- #168 (W-J) — display exclusion using namespace prefixes
- #169 (W-K) — JSON-LD emission using namespace slugs
- #170 (W-L) — llms.txt grouping by chapter

Keeping the slug / label vocabulary in a single module prevents drift across validators, UI, and machine-readable outputs.

## Acceptance criteria

- [x] `src/lib/taxonomy.ts` exists with four exports — `CHAPTER_SLUGS`, `WWH_SLUGS`, `CHAPTER_LABELS`, `WWH_LABELS`
- [x] All 7 chapter slugs + 4 W/W/H slugs present
- [x] Labels match HQ `content/strategy.md` § Reserved Tag Namespaces verbatim (transcribed from issue body; HQ#28 is the upstream authority)
- [x] `as const` assertions preserve literal types on SLUGS tuples (typecheck passes; `Record<(typeof CHAPTER_SLUGS)[number], string>` resolves to the correct literal union)
- [x] Module imports cleanly (deferred binding test to W-G #165 per AC)

## Test plan

- [x] `npm run typecheck` (astro check) — 0 errors, 0 warnings
- [x] `npm run lint` — clean
- [x] `npx vitest run src/lib/` — 38 tests pass, no regression
- [x] `npm run build` — completes successfully
- [x] `npx prettier --check src/lib/taxonomy.ts` — Prettier-clean
- [ ] CI (full gate: audit / lint / typecheck / test / build / Playwright / Lighthouse)

Refs #164

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)