### PR TITLE
(feat) add superRefine validation for namespaced tags per PDR-009 § 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "astro check",
+    "typecheck": "astro sync && astro check",
     "check:playwright-version-parity": "node scripts/check-playwright-version-parity.mjs",
     "test:audit:widths": "npm run build && node scripts/extract-widths.mjs",
     "test:audit:og-rss": "npm run build && node scripts/audit-og-rss.mjs"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,12 @@
 import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { z } from 'astro/zod';
-import { PILLAR_SLUGS, SERIES_SLUGS } from './lib/taxonomy';
+import {
+  CHAPTER_SLUGS,
+  PILLAR_SLUGS,
+  SERIES_SLUGS,
+  WWH_SLUGS,
+} from './lib/taxonomy';
 
 const blog = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
@@ -11,7 +16,54 @@ const blog = defineCollection({
     date: z.coerce.date(),
     pillar: z.enum(PILLAR_SLUGS),
     series: z.enum(SERIES_SLUGS).optional(),
-    tags: z.array(z.string()).default([]),
+    // Namespaced tag validation per PDR-009 § 4. Mirrors the strictness
+    // posture of z.enum on `pillar`: typos like `chapter:judgement`
+    // (British spelling) or duplicate namespace tags fail the build
+    // rather than silently breaking filter URLs and JSON-LD downstream.
+    tags: z
+      .array(z.string())
+      .default([])
+      .superRefine((tags, ctx) => {
+        const chapterTags = tags.filter((t) => t.startsWith('chapter:'));
+        const wwhTags = tags.filter((t) => t.startsWith('wwh:'));
+
+        if (chapterTags.length > 1) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `At most one chapter: tag allowed, found: ${chapterTags.join(', ')}`,
+          });
+        }
+
+        if (wwhTags.length > 1) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `Only one wwh: tag allowed, found: ${wwhTags.join(', ')}`,
+          });
+        }
+
+        for (const [idx, tag] of tags.entries()) {
+          if (tag.startsWith('chapter:')) {
+            const slug = tag.slice('chapter:'.length);
+            if (!(CHAPTER_SLUGS as readonly string[]).includes(slug)) {
+              ctx.addIssue({
+                code: 'custom',
+                path: [idx],
+                message: `Unknown chapter slug: "${slug}". Valid: ${CHAPTER_SLUGS.join(', ')}`,
+              });
+            }
+          }
+          if (tag.startsWith('wwh:')) {
+            const slug = tag.slice('wwh:'.length);
+            if (!(WWH_SLUGS as readonly string[]).includes(slug)) {
+              ctx.addIssue({
+                code: 'custom',
+                path: [idx],
+                message: `Unknown wwh slug: "${slug}". Valid: ${WWH_SLUGS.join(', ')}`,
+              });
+            }
+          }
+        }
+      }),
     readingTime: z.number().optional(),
     draft: z.boolean().default(false),
   }),


### PR DESCRIPTION
## Summary

Closes #165. Adds `superRefine` validation to the `tags` field in `src/content.config.ts` to enforce PDR-009 § 4 namespaced-tag conventions at build time, matching the strictness posture of `z.enum(PILLAR_SLUGS)` already in place for `pillar`.

## Changes

- **`src/content.config.ts`** — import `CHAPTER_SLUGS` and `WWH_SLUGS` from `./lib/taxonomy` (added in #164), wrap the `tags` array schema with `superRefine`:
  - Cardinality: reject >1 `chapter:*` or >1 `wwh:*` tag per post.
  - Slug-validity: reject any `chapter:*` or `wwh:*` whose suffix is not in the canonical slug list.
- **`package.json`** — `typecheck` script: `astro check` → `astro sync && astro check`. Ensures `.astro/collections/*` content-layer types are regenerated from updated schemas before checking. (`astro check` alone does not invoke sync; schema-only edits would otherwise type-check against stale generated types.)

One minor deviation from PDR-009 § 4 reference: `code: z.ZodIssueCode.custom` → `code: 'custom'`. Astro 6 ships Zod v4 (via `astro/zod`), where `z.ZodIssueCode` is explicitly deprecated — `node_modules/zod/v4/classic/compat.d.ts:10` carries a `@deprecated Use the raw string literal codes instead, e.g. "invalid_type"`. String literal is semantically identical (`z.ZodIssueCode.custom === 'custom'`).

## Why this ordering in CI

PDR-009 § Rationale requires `astro sync && astro check && astro build` in this order because:

1. `astro sync` regenerates `.astro/collections/*.d.ts` from the current schema. Schema edits (like this one) require regeneration.
2. `astro check` validates TypeScript usage against those fresh types.
3. `astro build` validates per-entry content frontmatter against the schema (what catches `chapter:judgement` in blog posts).

Build alone does NOT re-run content-layer type checking, and `astro check` does not auto-sync. Hence the explicit chain.

Effective CI order after this PR:

- `ci.yml` step "Type check" → `npm run typecheck` → `astro sync && astro check`
- `ci.yml` step "Build" → `npm run build` → `astro build`

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings (pre-existing `visibleCount` hint in `BlogFilter.astro` out of scope).
- [x] `npm run lint` — clean.
- [x] `npm run test` — 164/164 passed.
- [x] `npm run build` — 5 pages built, existing `sample-post.md` (no namespaced tags) unaffected.
- [x] **Local invalid-slug verification (AC bullet 4)** — created ephemeral `src/content/blog/__test-invalid-slug.md` with `chapter:judgement`, confirmed build failed with:
  ```
  tags.0: Unknown chapter slug: "judgement". Valid: first-moves, mental-models, interaction, judgment, workflow, where-you-are, meta-skill
  ```
  Location in error: `src/content/blog/__test-invalid-slug.md:0:0`. Test file removed before commit.
- [x] **Cardinality verification** — ephemeral post with `chapter:judgment + chapter:workflow` produced `At most one chapter: tag allowed, found: chapter:judgment, chapter:workflow`. Same for `wwh:`. Test file removed.
- [x] **`wwh:` branch verification** — ephemeral post with `wwh:nonexistent-slug` produced `Unknown wwh slug: "nonexistent-slug". Valid: what-works, when-to-use, how-to-do, meta-outside`. Test file removed.

## Launch-gating

Yes — launch-gating per PDR § 7. Without this, namespaced-tag strictness is not enforced and the rule actively weakens the current `z.enum` posture.

## Unblocks

- #169 (W-K JSON-LD)
- #170 (W-L llms.txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)