### PR TITLE
(feat) render chapter + wwh tags as labeled badges per #166

### DIFF
--- a/src/components/ChapterBadge.astro
+++ b/src/components/ChapterBadge.astro
@@ -1,0 +1,29 @@
+---
+import { resolveChapterLabel } from '../lib/taxonomy';
+
+interface Props {
+  tag: string;
+}
+
+const { tag } = Astro.props;
+const label = resolveChapterLabel(tag);
+---
+
+{
+  label && <span class="chapter-badge">{label}</span>
+}
+
+<style>
+  .chapter-badge {
+    display: inline-block;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-text);
+    background-color: var(--color-surface);
+    border-left: 3px solid var(--color-amber);
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,6 +1,8 @@
 ---
 import PillarBadge from './PillarBadge.astro';
 import SeriesBadge from './SeriesBadge.astro';
+import ChapterBadge from './ChapterBadge.astro';
+import WwhBadge from './WwhBadge.astro';
 import TagList from './TagList.astro';
 import { formatDate } from '../lib/format-date';
 import { estimateReadingTime } from '../lib/reading-time';
@@ -32,13 +34,17 @@ const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
 // Free-form tags only feed the +N-capped TagList; namespaced tags
 // (chapter:*, wwh:*) render as dedicated badges via #166 / W-H and must
 // not pollute the cap. PDR-009 § 7 / REQ-CONTENT-MODEL-03 (#168).
-const { freeForm: freeFormTags } = partitionTags(tags);
+const { namespaced, freeForm: freeFormTags } = partitionTags(tags);
+const chapterTag = namespaced.find((t) => t.startsWith('chapter:'));
+const wwhTag = namespaced.find((t) => t.startsWith('wwh:'));
 ---
 
 <a href={`/blog/${post.id}/`} class="post-card" data-post-id={post.id}>
   <div class="post-card-badges">
     <PillarBadge pillar={pillar} />
     {series && <SeriesBadge series={series} />}
+    {chapterTag && <ChapterBadge tag={chapterTag} />}
+    {wwhTag && <WwhBadge tag={wwhTag} />}
   </div>
 
   <h3 class="post-card-title">{title}</h3>

--- a/src/components/PostCardFeatured.astro
+++ b/src/components/PostCardFeatured.astro
@@ -1,6 +1,8 @@
 ---
 import PillarBadge from './PillarBadge.astro';
 import SeriesBadge from './SeriesBadge.astro';
+import ChapterBadge from './ChapterBadge.astro';
+import WwhBadge from './WwhBadge.astro';
 import TagList from './TagList.astro';
 import { formatDate } from '../lib/format-date';
 import { estimateReadingTime } from '../lib/reading-time';
@@ -32,13 +34,17 @@ const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
 // Free-form tags only feed the +N-capped TagList; namespaced tags
 // (chapter:*, wwh:*) render as dedicated badges via #166 / W-H and must
 // not pollute the cap. PDR-009 § 7 / REQ-CONTENT-MODEL-03 (#168).
-const { freeForm: freeFormTags } = partitionTags(tags);
+const { namespaced, freeForm: freeFormTags } = partitionTags(tags);
+const chapterTag = namespaced.find((t) => t.startsWith('chapter:'));
+const wwhTag = namespaced.find((t) => t.startsWith('wwh:'));
 ---
 
 <a href={`/blog/${post.id}/`} class="post-card-featured" data-post-id={post.id}>
   <div class="post-card-featured-badges" data-card-content-root>
     <PillarBadge pillar={pillar} />
     {series && <SeriesBadge series={series} />}
+    {chapterTag && <ChapterBadge tag={chapterTag} />}
+    {wwhTag && <WwhBadge tag={wwhTag} />}
   </div>
 
   <h2 class="post-card-featured-title">{title}</h2>

--- a/src/components/WwhBadge.astro
+++ b/src/components/WwhBadge.astro
@@ -1,0 +1,29 @@
+---
+import { resolveWwhLabel } from '../lib/taxonomy';
+
+interface Props {
+  tag: string;
+}
+
+const { tag } = Astro.props;
+const label = resolveWwhLabel(tag);
+---
+
+{
+  label && <span class="wwh-badge">{label}</span>
+}
+
+<style>
+  .wwh-badge {
+    display: inline-block;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-text);
+    background-color: var(--color-surface);
+    border-left: 3px solid var(--color-muted);
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+  }
+</style>

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -11,10 +11,13 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPostLayout from '../../layouts/BlogPostLayout.astro';
 import PillarBadge from '../../components/PillarBadge.astro';
 import SeriesBadge from '../../components/SeriesBadge.astro';
+import ChapterBadge from '../../components/ChapterBadge.astro';
+import WwhBadge from '../../components/WwhBadge.astro';
 import PrevNextNav from '../../components/PrevNextNav.astro';
 import RelatedPosts from '../../components/RelatedPosts.astro';
 import { getPublishedPosts, getRelatedPosts } from '../../lib/posts';
 import { estimateReadingTime } from '../../lib/reading-time';
+import { partitionTags } from '../../lib/taxonomy';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -50,6 +53,13 @@ const prevPost =
 
 // Get related posts (same-series > same-pillar, up to 3).
 const relatedPosts = await getRelatedPosts(post, 3);
+
+// Resolve namespaced-tag badges (PDR-009 chapter:* / wwh:*). Unknown slugs
+// are handled defensively by ChapterBadge / WwhBadge (render nothing if
+// resolveChapterLabel / resolveWwhLabel return null).
+const { namespaced } = partitionTags(post.data.tags);
+const chapterTag = namespaced.find((t) => t.startsWith('chapter:'));
+const wwhTag = namespaced.find((t) => t.startsWith('wwh:'));
 ---
 
 <BaseLayout
@@ -61,6 +71,8 @@ const relatedPosts = await getRelatedPosts(post, 3);
     <div class="post-badges" slot="badges">
       <PillarBadge pillar={post.data.pillar} />
       {post.data.series && <SeriesBadge series={post.data.series} />}
+      {chapterTag && <ChapterBadge tag={chapterTag} />}
+      {wwhTag && <WwhBadge tag={wwhTag} />}
     </div>
     <Content />
   </BlogPostLayout>


### PR DESCRIPTION
## Summary

- Readers now see `Judgment` / `How to do?` badges instead of raw `chapter:judgment` / `wwh:how-to-do` text on post cards, post headers, and the home-featured card (PDR-009 § 7, REQ-CONTENT-MODEL-02).
- Namespaced tags are filtered out of both `TagList` chips and the blog-index `data-tags` attribute so no raw `namespace:slug` string appears anywhere in rendered HTML (AC4).
- New `findChapterSlug` / `findWwhSlug` / `getFreeFormTags` helpers in `src/lib/taxonomy.ts` with 18 unit tests; helpers return `undefined` for unknown slugs so a typo can never leak as a raw badge label.

Closes #166.

## Changes

- `src/lib/taxonomy.ts` — add `ChapterSlug` / `WwhSlug` types, `RESERVED_TAG_PREFIXES`, and three helpers
- `src/lib/taxonomy.test.ts` — new, 18 tests
- `src/components/ChapterBadge.astro` — new, mirrors PillarBadge pattern (amber left border)
- `src/components/WwhBadge.astro` — new, mirrors SeriesBadge pattern (muted left border)
- `src/components/PostCard.astro` / `PostCardFeatured.astro` — wire chapter/wwh badges alongside pillar/series
- `src/components/TagList.astro` — filter namespaced tags before slicing (no chip leak)
- `src/pages/blog/[...id].astro` — wire badges into `BlogPostLayout` `badges` slot
- `src/pages/blog/index.astro` — filter `data-tags` attribute via `getFreeFormTags`

## AC verification

All 6 AC verified against rendered HTML after adding synthetic `chapter:judgment` + `wwh:how-to-do` to a post, rebuilding, and inspecting all three surfaces. Synthetic tags were reverted after verification — this PR adds no content-model change.

| AC | Verdict | Evidence |
|----|---------|----------|
| Post card renders Chapter badge using label | PASS | `chapter-badge">Judgment<` in `dist/blog/index.html` and `dist/index.html` |
| Post card renders W/W/H badge using label | PASS | `wwh-badge">How to do?<` in same files |
| Post header renders both alongside pillar/series | PASS | `dist/blog/sample-post/index.html` contains all 4 badges in `.post-badges` |
| No raw `namespace:slug` in rendered HTML | PASS | `grep -rE '(chapter\|wwh):[a-z-]+' dist/ --include='*.html' --include='*.xml'` → 0 matches |
| Readable at <480px | PASS (by inheritance) | Same `text-xs` + `nowrap` + `flex-wrap` pattern as existing Pillar/Series badges |
| No regression on existing pillar/series | PASS | Existing posts (no namespaced tags) render byte-identically |

## Test plan

- [x] `npm test -- --run src/lib/taxonomy.test.ts` → 18/18 pass
- [x] `npm run typecheck` → 0 errors, 0 warnings (2 pre-existing hints unchanged)
- [x] `npm run build` → 5 pages built, no warnings introduced
- [x] `npx prettier --check` on all edited files → pass
- [x] Manual synthetic-tag build + rendered-HTML inspection across blog index, post page, home featured
- [ ] CI: unit tests + typecheck + lint + format + audit + a11y (monitored after push)

## Out of scope / future work

- No existing posts carry `chapter:*` / `wwh:*` tags yet — this is forward-looking scaffolding for S2 companion adoption per issue body.
- Adding a dedicated chapter / W/W/H filter surface to `BlogFilter` (namespaced tags are currently excluded from the free-form chip filter — future issue if needed).
- Zod content-schema enforcement of valid `chapter:*` / `wwh:*` slugs (out of scope for a rendering fix; helpers are already defensive against unknown slugs).