### PR TITLE
(feat) resolve chapter/wwh tag labels in BlogFilter (#167)

### DIFF
--- a/src/components/BlogFilter.astro
+++ b/src/components/BlogFilter.astro
@@ -5,8 +5,14 @@
  * Reads ?pillar=, ?series=, ?tag= and ?page= from the URL on mount.
  * Sets display:none on non-matching card wrappers via data attributes.
  * Updates the URL via history.replaceState.
- * Shows active filter chips with "X" to remove.
+ * Shows active filter chips with "X" to remove. Namespaced tags
+ * (`chapter:*`, `wwh:*`, PDR-009) resolve to human-readable labels via
+ * `formatTagChipLabel` — never shown as raw `namespace:slug` per
+ * REQ-CONTENT-MODEL-02 GWT.
  * Combined filters use AND logic.
+ * Empty-state message follows REQ-INDEX-03 ("No posts in [filter name]
+ * yet.") when exactly one filter is active; multi-filter and no-filter
+ * cases use a generic fallback.
  * Client-side pagination: shows/hides sets of 12 posts.
  */
 ---
@@ -25,12 +31,19 @@
   <div class="sr-only" id="filter-live" aria-live="polite" aria-atomic="true">
   </div>
 
-  <!-- Empty state (hidden by default) -->
+  <!--
+    Empty state (hidden by default).
+
+    The message text is injected by the island script per REQ-INDEX-03:
+    "No posts in [filter name] yet." when a single filter is active,
+    with [filter name] resolved via the label-resolution helpers in
+    `src/lib/taxonomy.ts` (REQ-CONTENT-MODEL-02 for chapter:*/wwh:*).
+    Multi-filter and no-filter cases fall back to a generic message.
+  -->
   <div class="empty-state" id="empty-state" hidden>
     <p>
-      No posts match your filters. <a href="/blog/" id="clear-filters-link"
-        >Show all posts</a
-      >
+      <span id="empty-state-message">No posts match your filters.</span>
+      <a href="/blog/" id="clear-filters-link">Show all posts</a>
     </p>
   </div>
 
@@ -261,7 +274,12 @@
 </style>
 
 <script>
-  import { PILLARS, SERIES } from '../lib/taxonomy';
+  import {
+    PILLARS,
+    SERIES,
+    formatTagChipLabel,
+    formatEmptyStateFilterName,
+  } from '../lib/taxonomy';
 
   const POSTS_PER_PAGE = 12;
 
@@ -272,6 +290,7 @@
     const grid = document.getElementById('post-grid');
     const chipsContainer = document.getElementById('filter-chips');
     const emptyState = document.getElementById('empty-state');
+    const emptyStateMessage = document.getElementById('empty-state-message');
     const pagination = document.getElementById('pagination');
     const prevBtn = document.getElementById(
       'pagination-prev',
@@ -287,6 +306,7 @@
       !grid ||
       !chipsContainer ||
       !emptyState ||
+      !emptyStateMessage ||
       !pagination ||
       !prevBtn ||
       !nextBtn ||
@@ -369,8 +389,12 @@
         );
       }
       if (filters.tag) {
+        // Namespaced tags (chapter:*/wwh:*) resolve to human-readable
+        // labels per REQ-CONTENT-MODEL-02; free-form tags render with
+        // `#` prefix (unchanged). Unknown namespaced slugs fall through
+        // to the raw string — see `formatTagChipLabel` in taxonomy.ts.
         chipsContainer!.appendChild(
-          createChip('tag', filters.tag, `#${filters.tag}`),
+          createChip('tag', filters.tag, formatTagChipLabel(filters.tag)),
         );
       }
     }
@@ -513,15 +537,38 @@
       // UI updates
       const hasFilters = !!(filters.pillar || filters.series || filters.tag);
       emptyState!.hidden = matching.length > 0;
+      // REQ-INDEX-03 empty-state template: "No posts in [filter name]
+      // yet." when exactly one filter is active, with [filter name]
+      // resolved via `formatEmptyStateFilterName`. Zero or multiple
+      // active filters fall back to the generic baseline message.
+      // Assignment uses textContent (not innerHTML) so crafted URL
+      // values cannot inject markup into the chip button or the
+      // empty-state message — matches the chip-rendering constraint
+      // documented above `createChip`.
+      if (matching.length === 0) {
+        const filterName = formatEmptyStateFilterName(filters);
+        emptyStateMessage!.textContent = filterName
+          ? `No posts in ${filterName} yet.`
+          : 'No posts match your filters.';
+      }
       renderChips(filters);
       renderPagination(matching.length, currentPage, totalPages);
 
-      // Announce results to screen readers
+      // Announce results to screen readers. The empty-state announcement
+      // mirrors the visible empty-state message above (REQ-INDEX-03 +
+      // REQ-CONTENT-MODEL-02) so auditory and visual experiences stay
+      // in sync — cherry-picking the label resolution for sighted users
+      // only would diverge from WCAG 2.2 AA auditory equivalence.
       if (liveRegion && hasFilters) {
-        const msg =
-          matching.length === 0
-            ? 'No posts match your filters.'
-            : `${matching.length} post${matching.length === 1 ? '' : 's'} found.`;
+        let msg: string;
+        if (matching.length === 0) {
+          const filterName = formatEmptyStateFilterName(filters);
+          msg = filterName
+            ? `No posts in ${filterName} yet.`
+            : 'No posts match your filters.';
+        } else {
+          msg = `${matching.length} post${matching.length === 1 ? '' : 's'} found.`;
+        }
         liveRegion.textContent = msg;
       } else if (liveRegion) {
         liveRegion.textContent = '';

--- a/src/lib/taxonomy.test.ts
+++ b/src/lib/taxonomy.test.ts
@@ -186,7 +186,7 @@ describe('resolveChapterLabel', () => {
   });
 
   it('returns null for unknown chapter slugs (no runtime crash)', () => {
-    expect(resolveChapterLabel('chapter:judgement')).toBeNull(); // British mis-spell
+    expect(resolveChapterLabel('chapter:judgement')).toBeNull(); // British misspelling
     expect(resolveChapterLabel('chapter:nonexistent')).toBeNull();
     expect(resolveChapterLabel('chapter:')).toBeNull();
   });

--- a/src/lib/taxonomy.test.ts
+++ b/src/lib/taxonomy.test.ts
@@ -3,6 +3,10 @@ import {
   RESERVED_NAMESPACES,
   isNamespacedTag,
   partitionTags,
+  resolveChapterLabel,
+  resolveWwhLabel,
+  formatTagChipLabel,
+  formatEmptyStateFilterName,
 } from './taxonomy';
 
 describe('RESERVED_NAMESPACES', () => {
@@ -163,5 +167,176 @@ describe('partitionTags', () => {
       expect(freeForm).toHaveLength(0);
       expect(namespaced).toHaveLength(2);
     });
+  });
+});
+
+describe('resolveChapterLabel', () => {
+  it('returns human label for known chapter slugs', () => {
+    expect(resolveChapterLabel('chapter:judgment')).toBe('Judgment');
+    expect(resolveChapterLabel('chapter:first-moves')).toBe('First Moves');
+    expect(resolveChapterLabel('chapter:mental-models')).toBe('Mental Models');
+    expect(resolveChapterLabel('chapter:where-you-are')).toBe('Where You Are');
+    expect(resolveChapterLabel('chapter:meta-skill')).toBe('Meta-skill');
+  });
+
+  it('returns null for non-chapter tags', () => {
+    expect(resolveChapterLabel('claude')).toBeNull();
+    expect(resolveChapterLabel('wwh:what-works')).toBeNull();
+    expect(resolveChapterLabel('')).toBeNull();
+  });
+
+  it('returns null for unknown chapter slugs (no runtime crash)', () => {
+    expect(resolveChapterLabel('chapter:judgement')).toBeNull(); // British mis-spell
+    expect(resolveChapterLabel('chapter:nonexistent')).toBeNull();
+    expect(resolveChapterLabel('chapter:')).toBeNull();
+  });
+});
+
+describe('resolveWwhLabel', () => {
+  it('returns human label for known wwh slugs', () => {
+    expect(resolveWwhLabel('wwh:what-works')).toBe('What works?');
+    expect(resolveWwhLabel('wwh:when-to-use')).toBe('When to use?');
+    expect(resolveWwhLabel('wwh:how-to-do')).toBe('How to do?');
+    expect(resolveWwhLabel('wwh:meta-outside')).toBe('Meta');
+  });
+
+  it('returns null for non-wwh tags', () => {
+    expect(resolveWwhLabel('claude')).toBeNull();
+    expect(resolveWwhLabel('chapter:judgment')).toBeNull();
+    expect(resolveWwhLabel('')).toBeNull();
+  });
+
+  it('returns null for unknown wwh slugs (no runtime crash)', () => {
+    expect(resolveWwhLabel('wwh:nonexistent')).toBeNull();
+    expect(resolveWwhLabel('wwh:')).toBeNull();
+  });
+});
+
+describe('formatTagChipLabel', () => {
+  // REQ-CONTENT-MODEL-02 GWT — active filter chip label resolution.
+  it('resolves chapter:judgment to the human-readable label "Judgment"', () => {
+    expect(formatTagChipLabel('chapter:judgment')).toBe('Judgment');
+  });
+
+  it('resolves wwh:what-works to "What works?"', () => {
+    expect(formatTagChipLabel('wwh:what-works')).toBe('What works?');
+  });
+
+  it('renders free-form tag with # prefix (unchanged behavior)', () => {
+    // Issue #167 AC: "Free-form tag chips unchanged". Current rendering
+    // is `#${tag}` — preserve that for non-namespaced tags.
+    expect(formatTagChipLabel('claude')).toBe('#claude');
+    expect(formatTagChipLabel('workflow')).toBe('#workflow');
+  });
+
+  it('renders non-reserved colon-tags with # prefix', () => {
+    // Only `chapter:` and `wwh:` are reserved namespaces (taxonomy.ts).
+    // Ad-hoc colon tags (`tool:vim`, `lang:ts`) are free-form and must
+    // keep their `#` prefix — matching pre-PDR-009 chip rendering and
+    // the `isNamespacedTag` predicate from #175.
+    expect(formatTagChipLabel('tool:vim')).toBe('#tool:vim');
+    expect(formatTagChipLabel('lang:ts')).toBe('#lang:ts');
+  });
+
+  it('falls through to raw string for unknown namespaced tag (no crash)', () => {
+    // Build-time superRefine rejects invalid namespaced slugs, but URL
+    // query params carry arbitrary strings at runtime. The component
+    // must not throw when a handcrafted URL supplies an unknown slug.
+    expect(formatTagChipLabel('chapter:unknown-slug')).toBe(
+      'chapter:unknown-slug',
+    );
+    expect(formatTagChipLabel('wwh:nonexistent')).toBe('wwh:nonexistent');
+  });
+
+  it('treats empty string as free-form', () => {
+    // Matches current behavior of the # prefix path.
+    expect(formatTagChipLabel('')).toBe('#');
+  });
+});
+
+describe('formatEmptyStateFilterName', () => {
+  // REQ-CONTENT-MODEL-02 GWT — empty-state message resolves namespaced
+  // labels, not raw namespace:slug strings.
+  it('resolves chapter tag to human label', () => {
+    expect(
+      formatEmptyStateFilterName({
+        pillar: '',
+        series: '',
+        tag: 'chapter:judgment',
+      }),
+    ).toBe('Judgment');
+  });
+
+  it('resolves wwh tag to human label', () => {
+    expect(
+      formatEmptyStateFilterName({
+        pillar: '',
+        series: '',
+        tag: 'wwh:what-works',
+      }),
+    ).toBe('What works?');
+  });
+
+  // REQ-INDEX-03 GWT — empty-state uses resolved pillar/series labels.
+  it('resolves pillar to human label', () => {
+    expect(
+      formatEmptyStateFilterName({ pillar: 'meta', series: '', tag: '' }),
+    ).toBe('Behind the Scenes');
+  });
+
+  it('resolves series to human label', () => {
+    expect(
+      formatEmptyStateFilterName({
+        pillar: '',
+        series: 'ai-at-home',
+        tag: '',
+      }),
+    ).toBe('AI at Home');
+  });
+
+  it('uses raw free-form tag as filter name', () => {
+    expect(
+      formatEmptyStateFilterName({ pillar: '', series: '', tag: 'claude' }),
+    ).toBe('claude');
+  });
+
+  it('falls through to raw for unknown namespaced tag slug', () => {
+    expect(
+      formatEmptyStateFilterName({
+        pillar: '',
+        series: '',
+        tag: 'chapter:unknown',
+      }),
+    ).toBe('chapter:unknown');
+  });
+
+  it('returns null when multiple filters are active (caller falls back to generic message)', () => {
+    expect(
+      formatEmptyStateFilterName({
+        pillar: 'meta',
+        series: '',
+        tag: 'claude',
+      }),
+    ).toBeNull();
+    expect(
+      formatEmptyStateFilterName({
+        pillar: 'meta',
+        series: 'ai-at-home',
+        tag: '',
+      }),
+    ).toBeNull();
+    expect(
+      formatEmptyStateFilterName({
+        pillar: '',
+        series: 'ai-at-home',
+        tag: 'chapter:judgment',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when no filters active', () => {
+    expect(
+      formatEmptyStateFilterName({ pillar: '', series: '', tag: '' }),
+    ).toBeNull();
   });
 });

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -120,3 +120,85 @@ export function partitionTags(tags: readonly string[]): {
   }
   return { namespaced, freeForm };
 }
+
+/**
+ * Resolve a `chapter:{slug}` tag to its human-readable label, or return
+ * `null` if the tag is not a known chapter. Typos and hand-crafted URL
+ * values (e.g., `chapter:judgement`) return null rather than throwing —
+ * build-time `superRefine` validation is the gate for editorial correctness;
+ * the filter UI receives whatever the URL carries at runtime.
+ */
+export function resolveChapterLabel(tag: string): string | null {
+  const PREFIX = 'chapter:';
+  if (!tag.startsWith(PREFIX)) return null;
+  const slug = tag.slice(PREFIX.length);
+  if (!(CHAPTER_SLUGS as readonly string[]).includes(slug)) return null;
+  return CHAPTER_LABELS[slug as (typeof CHAPTER_SLUGS)[number]];
+}
+
+/**
+ * Resolve a `wwh:{slug}` tag to its human-readable label, or return `null`
+ * if the tag is not a known W/W/H content type. See `resolveChapterLabel`
+ * for the unknown-slug rationale.
+ */
+export function resolveWwhLabel(tag: string): string | null {
+  const PREFIX = 'wwh:';
+  if (!tag.startsWith(PREFIX)) return null;
+  const slug = tag.slice(PREFIX.length);
+  if (!(WWH_SLUGS as readonly string[]).includes(slug)) return null;
+  return WWH_LABELS[slug as (typeof WWH_SLUGS)[number]];
+}
+
+/**
+ * Format a tag value for display as an active-filter chip on the blog
+ * index. Reserved namespaces (`chapter:*`, `wwh:*`) resolve to their
+ * human-readable labels per PDR-009 § 4 / REQ-CONTENT-MODEL-02 GWT.
+ * Free-form tags render as `#tag` (preserving pre-PDR-009 UI behavior).
+ * Unknown namespaced slugs fall through to the raw string rather than
+ * throwing so that hand-crafted URLs do not crash the client island.
+ * Non-reserved colon tags (`tool:vim`, `lang:ts`) are free-form and
+ * render with the `#` prefix — the reserved-namespace check uses
+ * `isNamespacedTag` (#175) so the gate matches the partition logic
+ * applied on post cards.
+ */
+export function formatTagChipLabel(tag: string): string {
+  return (
+    resolveChapterLabel(tag) ??
+    resolveWwhLabel(tag) ??
+    (isNamespacedTag(tag) ? tag : `#${tag}`)
+  );
+}
+
+/**
+ * Resolve the filter name for the empty-state template (REQ-INDEX-03:
+ * "No posts in [filter name] yet."). Returns `null` when zero or multiple
+ * filters are active, signalling that the caller should fall back to a
+ * generic "No posts match your filters." message.
+ *
+ * For tag filters, namespaced tags (`chapter:*`, `wwh:*`) resolve to their
+ * human-readable labels per REQ-CONTENT-MODEL-02; free-form tags return
+ * the raw tag string (no `#` prefix — the empty state reads as prose, not
+ * a tag affordance).
+ */
+export function formatEmptyStateFilterName(filters: {
+  pillar: string;
+  series: string;
+  tag: string;
+}): string | null {
+  const activeCount =
+    (filters.pillar ? 1 : 0) + (filters.series ? 1 : 0) + (filters.tag ? 1 : 0);
+  if (activeCount !== 1) return null;
+
+  if (filters.pillar) {
+    return PILLARS[filters.pillar as PillarSlug] ?? filters.pillar;
+  }
+  if (filters.series) {
+    return SERIES[filters.series as SeriesSlug] ?? filters.series;
+  }
+  // filters.tag is the only remaining non-empty field.
+  return (
+    resolveChapterLabel(filters.tag) ??
+    resolveWwhLabel(filters.tag) ??
+    filters.tag
+  );
+}

--- a/tests/audit/__baselines__/route-clusters.json
+++ b/tests/audit/__baselines__/route-clusters.json
@@ -6,7 +6,7 @@
       "registered": "2026-04-21"
     },
     "blog-index": {
-      "skeleton_hash": "94ebc53113a8ce0c332de6a1acf8994ac443750422f09f14f84814f083d8117e",
+      "skeleton_hash": "9d6e5d28361b4c1810b9c46c2bab524329b30cf32d5acacddd5fb500d4571e49",
       "canonical_path": "/blog/",
       "registered": "2026-04-21"
     },


### PR DESCRIPTION
## Summary

- `BlogFilter` active-filter chips resolve `chapter:*` / `wwh:*` tags through `CHAPTER_LABELS` / `WWH_LABELS` — "Judgment", "What works?" instead of the raw `namespace:slug` strings (REQ-CONTENT-MODEL-02, PDR-009 § 7 launch-gating item 10).
- Empty-state message uses the REQ-INDEX-03 template `"No posts in [filter name] yet."` for single-filter cases with label resolution per filter kind (pillar / series / chapter / wwh / free-form tag). Multi-filter and no-filter cases fall back to `"No posts match your filters."`. The aria-live announcement mirrors the visible message so auditory and visual empty states stay in sync (WCAG 2.2 AA equivalence).
- Four pure helpers added to `src/lib/taxonomy.ts` (`resolveChapterLabel`, `resolveWwhLabel`, `formatTagChipLabel`, `formatEmptyStateFilterName`) — alongside the existing SSoT constants — with 19 new unit tests exercising AC + adversarial cases.

## Context

Third W-ticket in the PDR-009 website-side chain after the `#164` taxonomy SSoT landed (merged as `#171`):

- `#164` W-F — `src/lib/taxonomy.ts` constants (merged, prerequisite)
- `#165` W-G — `content.config.ts` superRefine (independent)
- `#166` W-H — post-card / header badges (independent)
- **`#167` W-I — BlogFilter chip labels + empty-state (this PR)** ← launch-gating per PDR-009 § 7
- `#168` W-J — tag display exclusion from "+N more" count (independent, covers `TagList.astro` namespace rendering — out of scope here)
- `#169`, `#170` — JSON-LD, llms.txt (independent)

## Scope notes

- **Empty-state template expansion beyond namespaced tags**: AC #3 required namespaced-tag label resolution in the empty state. The existing empty state didn't implement REQ-INDEX-03 at all (showed `"No posts match your filters."` in every case). Cherry-picking only namespaced tags would leave the state inconsistent across filter kinds — same UI, same call site, different resolution source per filter. The empty state now renders `"No posts in [filter name] yet."` for every single-filter case (pillar, series, tag), closing REQ-INDEX-03 coherently while satisfying REQ-CONTENT-MODEL-02 GWT bullet 3.
- **Free-form tag chips unchanged**: AC #4 text `"still renders as 'claude'"` is parenthetical shorthand — the operative constraint is "unchanged". Git blame shows `#${tag}` has been the chip text since the original blog-filter feature commit (`5fd602d`); preserving it. `formatTagChipLabel('claude')` → `'#claude'`.
- **Out of scope**: `TagList.astro` still shows raw `chapter:judgment` strings in the post-card "3 visible + '+N more'" list. That belongs to `#168` (W-J display exclusion) per PDR-009 § 7 launch-gating item 11.
- **XSS posture preserved**: chip labels and empty-state message both assign via `textContent` (not `innerHTML`). URL-supplied tag values cannot inject markup. This matches the constraint documented above `createChip` in the pre-existing code.
- **Unknown slugs**: `chapter:unknown-slug` / `wwh:nonexistent` fall through to the raw string rather than throwing. Build-time `superRefine` (W-G `#165`) is the gate for editorial correctness; the client tolerates whatever the URL carries.

## Acceptance criteria

- [x] Given `?tag=chapter:judgment`, active filter chip displays "Judgment" — covered by `formatTagChipLabel('chapter:judgment') === 'Judgment'` test
- [x] Given `?tag=wwh:what-works`, active filter chip displays "What works?" — covered by `formatTagChipLabel('wwh:what-works') === 'What works?'` test
- [x] Empty-state message uses resolved label, not raw namespace:slug — `formatEmptyStateFilterName` has 8 cases (chapter, wwh, pillar, series, free-form, unknown, multi-filter, empty)
- [x] Free-form tag chips unchanged (`#claude`) — covered by test `renders free-form tag with # prefix (unchanged behavior)`
- [x] Unknown/unregistered namespaced tags fall through to raw string (no runtime crash) — covered by `formatTagChipLabel('chapter:unknown-slug') === 'chapter:unknown-slug'` test
- [x] Matches REQ-CONTENT-MODEL-02 GWT block in PRD (H-F) — GWT bullets 1, 2, 3 satisfied; bullet 4 (chapter badge) tracked by `#166`; bullet 5 "BUT NOT raw namespace:slug" satisfied

## Test plan

- [x] `npm run test` — 183 tests pass across 8 files (was 164; +19 new in `src/lib/taxonomy.test.ts`)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — 0 errors, 0 warnings (2 pre-existing hints unrelated: `eslint.config.js` tseslint deprecation + `BlogFilter.astro` `visibleCount` unused parameter, both present before this change)
- [x] `npx prettier --check src/components/BlogFilter.astro src/lib/taxonomy.ts src/lib/taxonomy.test.ts` — clean
- [x] `npm run build` — 5 pages emitted, 1.25s. Bundled `dist/_astro/BlogFilter.astro_astro_type_script_*.js` contains strings `"Judgment"`, `"What works"`, `"No posts in"` — label resolution reaches the client island
- [ ] CI (full gate: audit / lint / typecheck / test / build / QA-07/08/09 Playwright / QA-10.1/10.2/10.3/10.5 audits / Lighthouse QA-06)

Refs #167
Refs #164 (taxonomy SSoT prerequisite, merged as #171)
Refs hq/docs/decisions/PDR-009-schema-evolution-principle.md § 7 item 10
Refs hq/docs/website/prd.md § REQ-CONTENT-MODEL-02, REQ-INDEX-03

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)