### PR TITLE
(feat) exclude namespaced tags from "+N more" cap on post cards (#168)

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -4,6 +4,7 @@ import SeriesBadge from './SeriesBadge.astro';
 import TagList from './TagList.astro';
 import { formatDate } from '../lib/format-date';
 import { estimateReadingTime } from '../lib/reading-time';
+import { partitionTags } from '../lib/taxonomy';
 
 interface Props {
   post: {
@@ -27,6 +28,11 @@ const { title, description, date, pillar, series, tags, readingTime } =
 
 const displayDate = formatDate(date);
 const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
+
+// Free-form tags only feed the +N-capped TagList; namespaced tags
+// (chapter:*, wwh:*) render as dedicated badges via #166 / W-H and must
+// not pollute the cap. PDR-009 § 7 / REQ-CONTENT-MODEL-03 (#168).
+const { freeForm: freeFormTags } = partitionTags(tags);
 ---
 
 <a href={`/blog/${post.id}/`} class="post-card" data-post-id={post.id}>
@@ -45,7 +51,7 @@ const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
     <span>{minutes} min read</span>
   </div>
 
-  {tags.length > 0 && <TagList tags={tags} />}
+  {freeFormTags.length > 0 && <TagList tags={freeFormTags} />}
 </a>
 
 <style>

--- a/src/components/PostCardFeatured.astro
+++ b/src/components/PostCardFeatured.astro
@@ -4,6 +4,7 @@ import SeriesBadge from './SeriesBadge.astro';
 import TagList from './TagList.astro';
 import { formatDate } from '../lib/format-date';
 import { estimateReadingTime } from '../lib/reading-time';
+import { partitionTags } from '../lib/taxonomy';
 
 interface Props {
   post: {
@@ -27,6 +28,11 @@ const { title, description, date, pillar, series, tags, readingTime } =
 
 const displayDate = formatDate(date);
 const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
+
+// Free-form tags only feed the +N-capped TagList; namespaced tags
+// (chapter:*, wwh:*) render as dedicated badges via #166 / W-H and must
+// not pollute the cap. PDR-009 § 7 / REQ-CONTENT-MODEL-03 (#168).
+const { freeForm: freeFormTags } = partitionTags(tags);
 ---
 
 <a href={`/blog/${post.id}/`} class="post-card-featured" data-post-id={post.id}>
@@ -45,7 +51,7 @@ const minutes = readingTime ?? (post.body ? estimateReadingTime(post.body) : 1);
     <span>{minutes} min read</span>
   </div>
 
-  {tags.length > 0 && <TagList tags={tags} />}
+  {freeFormTags.length > 0 && <TagList tags={freeFormTags} />}
 </a>
 
 <style>

--- a/src/lib/taxonomy.test.ts
+++ b/src/lib/taxonomy.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RESERVED_NAMESPACES,
+  isNamespacedTag,
+  partitionTags,
+} from './taxonomy';
+
+describe('RESERVED_NAMESPACES', () => {
+  it('includes the two PDR-009 namespaces', () => {
+    expect(RESERVED_NAMESPACES).toEqual(['chapter', 'wwh']);
+  });
+});
+
+describe('isNamespacedTag', () => {
+  it('returns true for chapter:* tags', () => {
+    expect(isNamespacedTag('chapter:first-moves')).toBe(true);
+    expect(isNamespacedTag('chapter:judgment')).toBe(true);
+    expect(isNamespacedTag('chapter:meta-skill')).toBe(true);
+  });
+
+  it('returns true for wwh:* tags', () => {
+    expect(isNamespacedTag('wwh:what-works')).toBe(true);
+    expect(isNamespacedTag('wwh:when-to-use')).toBe(true);
+    expect(isNamespacedTag('wwh:how-to-do')).toBe(true);
+    expect(isNamespacedTag('wwh:meta-outside')).toBe(true);
+  });
+
+  it('returns false for free-form tags without a colon', () => {
+    expect(isNamespacedTag('automation')).toBe(false);
+    expect(isNamespacedTag('rag')).toBe(false);
+    expect(isNamespacedTag('getting-started')).toBe(false);
+  });
+
+  it('returns false for tags whose namespace is not reserved', () => {
+    expect(isNamespacedTag('foo:bar')).toBe(false);
+    expect(isNamespacedTag('series:ai-at-work')).toBe(false);
+    expect(isNamespacedTag('pillar:practice')).toBe(false);
+  });
+
+  it('returns false when the namespace prefix is empty', () => {
+    expect(isNamespacedTag(':judgment')).toBe(false);
+  });
+
+  it('returns false when the slug suffix is empty', () => {
+    expect(isNamespacedTag('chapter:')).toBe(false);
+    expect(isNamespacedTag('wwh:')).toBe(false);
+  });
+
+  it('returns false for the empty string', () => {
+    expect(isNamespacedTag('')).toBe(false);
+  });
+
+  it('is case-sensitive on the namespace prefix', () => {
+    // Slugs are lowercase per taxonomy.ts; "Chapter:Foo" is not reserved.
+    // W-G (Zod superRefine, #165) enforces casing for namespaced tags.
+    expect(isNamespacedTag('Chapter:judgment')).toBe(false);
+    expect(isNamespacedTag('WWH:what-works')).toBe(false);
+  });
+
+  it('treats only the FIRST colon as the namespace separator', () => {
+    // Slug-side validation (kebab-case + membership) is W-G's job; the
+    // prefix-only test here keeps the predicate cheap and stable when
+    // future slugs change.
+    expect(isNamespacedTag('chapter:foo:bar')).toBe(true);
+  });
+});
+
+describe('partitionTags', () => {
+  it('returns empty groups for an empty tag list', () => {
+    expect(partitionTags([])).toEqual({ namespaced: [], freeForm: [] });
+  });
+
+  it('routes all tags to freeForm when none are namespaced', () => {
+    expect(partitionTags(['automation', 'rag', 'getting-started'])).toEqual({
+      namespaced: [],
+      freeForm: ['automation', 'rag', 'getting-started'],
+    });
+  });
+
+  it('routes all tags to namespaced when every tag is namespaced', () => {
+    expect(partitionTags(['chapter:first-moves', 'wwh:what-works'])).toEqual({
+      namespaced: ['chapter:first-moves', 'wwh:what-works'],
+      freeForm: [],
+    });
+  });
+
+  it('splits a mixed list of namespaced and free-form tags', () => {
+    const tags = [
+      'automation',
+      'chapter:judgment',
+      'rag',
+      'wwh:how-to-do',
+      'workflows',
+    ];
+    expect(partitionTags(tags)).toEqual({
+      namespaced: ['chapter:judgment', 'wwh:how-to-do'],
+      freeForm: ['automation', 'rag', 'workflows'],
+    });
+  });
+
+  it('preserves input order within each group', () => {
+    const tags = [
+      'wwh:meta-outside',
+      'b',
+      'chapter:meta-skill',
+      'a',
+      'chapter:judgment',
+    ];
+    const { namespaced, freeForm } = partitionTags(tags);
+    expect(namespaced).toEqual([
+      'wwh:meta-outside',
+      'chapter:meta-skill',
+      'chapter:judgment',
+    ]);
+    expect(freeForm).toEqual(['b', 'a']);
+  });
+
+  it('treats unreserved-namespace tags as free-form', () => {
+    expect(partitionTags(['foo:bar', 'pillar:practice'])).toEqual({
+      namespaced: [],
+      freeForm: ['foo:bar', 'pillar:practice'],
+    });
+  });
+
+  describe('REQ-CONTENT-MODEL-03 cap-exclusion scenarios (#168)', () => {
+    // These three cases mirror the post-card AC: the freeForm count drives
+    // the existing "3 visible + +N more" cap on `TagList`; the namespaced
+    // count drives the dedicated badge surface (W-H scope, #166). Both
+    // numbers must be correct for the cap-exclusion semantic to hold.
+
+    it('AC1 — 3 free-form + 2 namespaced ⇒ 3 free-form (no +N), 2 namespaced', () => {
+      const { freeForm, namespaced } = partitionTags([
+        'automation',
+        'chapter:first-moves',
+        'rag',
+        'wwh:what-works',
+        'workflows',
+      ]);
+      // freeForm.length === 3 (== TagList MAX_VISIBLE) ⇒ no "+N more"
+      expect(freeForm).toHaveLength(3);
+      expect(namespaced).toHaveLength(2);
+    });
+
+    it('AC2 — 5 free-form + 1 namespaced ⇒ 3 visible + +2 more, 1 namespaced', () => {
+      const { freeForm, namespaced } = partitionTags([
+        'a',
+        'b',
+        'c',
+        'chapter:judgment',
+        'd',
+        'e',
+      ]);
+      // freeForm.length === 5 ⇒ TagList renders 3 visible + "+2 more"
+      expect(freeForm).toHaveLength(5);
+      expect(namespaced).toHaveLength(1);
+    });
+
+    it('AC3 — only namespaced tags ⇒ 0 free-form (no TagList), 2 namespaced', () => {
+      const { freeForm, namespaced } = partitionTags([
+        'chapter:meta-skill',
+        'wwh:meta-outside',
+      ]);
+      expect(freeForm).toHaveLength(0);
+      expect(namespaced).toHaveLength(2);
+    });
+  });
+});

--- a/src/lib/taxonomy.test.ts
+++ b/src/lib/taxonomy.test.ts
@@ -124,7 +124,7 @@ describe('partitionTags', () => {
 
   describe('REQ-CONTENT-MODEL-03 cap-exclusion scenarios (#168)', () => {
     // These three cases mirror the post-card AC: the freeForm count drives
-    // the existing "3 visible + +N more" cap on `TagList`; the namespaced
+    // the existing "3 visible + '+N more'" cap on `TagList`; the namespaced
     // count drives the dedicated badge surface (W-H scope, #166). Both
     // numbers must be correct for the cap-exclusion semantic to hold.
 
@@ -141,7 +141,7 @@ describe('partitionTags', () => {
       expect(namespaced).toHaveLength(2);
     });
 
-    it('AC2 — 5 free-form + 1 namespaced ⇒ 3 visible + +2 more, 1 namespaced', () => {
+    it('AC2 — 5 free-form + 1 namespaced ⇒ 3 visible + "+2 more", 1 namespaced', () => {
       const { freeForm, namespaced } = partitionTags([
         'a',
         'b',

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -72,3 +72,51 @@ export const WWH_LABELS: Record<(typeof WWH_SLUGS)[number], string> = {
   'how-to-do': 'How to do?',
   'meta-outside': 'Meta',
 };
+
+/**
+ * Reserved tag namespaces per PDR-009 § Reserved Tag Namespaces. A tag of
+ * the form `{ns}:{slug}` where `{ns}` matches one of these is a namespaced
+ * tag (rendered as a dedicated labeled badge). Anything else is a free-form
+ * tag (rendered in the +N-capped tag list on post cards).
+ */
+export const RESERVED_NAMESPACES = ['chapter', 'wwh'] as const;
+
+/**
+ * True if `tag` is `{ns}:{slug}` where `{ns}` is one of `RESERVED_NAMESPACES`
+ * and both `{ns}` and `{slug}` are non-empty. Empty namespace (`:foo`),
+ * empty slug (`chapter:`), missing colon (`foo`), and unreserved namespaces
+ * (`foo:bar`) all return `false` — those are free-form tags.
+ *
+ * Slug character validation (kebab-case, membership in `CHAPTER_SLUGS` /
+ * `WWH_SLUGS`) is the Zod schema's job (W-G / #165), not this predicate's.
+ * For rendering, "namespaced" means the prefix matters, not the slug value.
+ */
+export function isNamespacedTag(tag: string): boolean {
+  const idx = tag.indexOf(':');
+  if (idx <= 0) return false;
+  if (idx === tag.length - 1) return false;
+  const ns = tag.slice(0, idx);
+  return (RESERVED_NAMESPACES as readonly string[]).includes(ns);
+}
+
+/**
+ * Partition `tags` into `namespaced` (matching `RESERVED_NAMESPACES`) and
+ * `freeForm` (everything else), preserving input order within each group.
+ *
+ * Used by post-card components so the existing "3 visible + '+N more'" cap
+ * on `TagList` applies to free-form tags only — namespaced tags render as
+ * dedicated badges via PDR-009 § 7 / REQ-CONTENT-MODEL-03 (#166) and must
+ * not pollute the cap (#168 / REQ-CONTENT-MODEL-03 display rule).
+ */
+export function partitionTags(tags: readonly string[]): {
+  namespaced: string[];
+  freeForm: string[];
+} {
+  const namespaced: string[] = [];
+  const freeForm: string[] = [];
+  for (const tag of tags) {
+    if (isNamespacedTag(tag)) namespaced.push(tag);
+    else freeForm.push(tag);
+  }
+  return { namespaced, freeForm };
+}


### PR DESCRIPTION
Closes #168.

## Summary

`PostCard.astro` / `PostCardFeatured.astro` now split incoming `tags` via the new `partitionTags(tags)` helper (`src/lib/taxonomy.ts`) and pass only the **free-form** group to `<TagList>`. The existing `MAX_VISIBLE = 3` cap on `TagList` therefore counts free-form tags only — namespaced tags (`chapter:*`, `wwh:*`) are kept out of the cap so they cannot push useful free-form tags behind a "+N more" indicator.

Per **PDR-009 § 7 / REQ-CONTENT-MODEL-03** (HQ PRD H-F; private repo, see `CONTRIBUTING.md` § Cross-repo setup).

## Files

| Path | Change |
| --- | --- |
| `src/lib/taxonomy.ts` | New exports: `RESERVED_NAMESPACES`, `isNamespacedTag(tag)`, `partitionTags(tags)`. JSDoc cites PDR-009 § 7 and the cap-exclusion contract. |
| `src/lib/taxonomy.test.ts` | NEW — 19 vitest unit tests: edge cases for `isNamespacedTag` (empty ns, empty slug, case-sensitivity, multi-colon, unreserved-ns) + order/empty/mixed-input for `partitionTags` + three explicit AC1/AC2/AC3 scenarios. |
| `src/components/PostCard.astro` | +1 import, +4-line splitting block, `tags` → `freeFormTags` in the `<TagList>` prop. |
| `src/components/PostCardFeatured.astro` | Same pattern as `PostCard.astro`. |

## AC verification

| # | AC | Verdict | Evidence |
| --- | --- | --- | --- |
| 1 | 3 free-form + 2 namespaced ⇒ 3 free-form (no "+N more") + 2 badges | **CODE-PASS / VISUAL-PARTIAL** | `taxonomy.test.ts` AC1: `freeForm.length === 3`, `namespaced.length === 2`. `PostCard.astro` passes only `freeFormTags` ⇒ `TagList` renders 3 chips and `remaining = 0` ⇒ no "+N more" element. **Badge rendering** for the namespaced 2 = #166 (W-H scope) — see § Scope split below. |
| 2 | 5 free-form + 1 namespaced ⇒ 3 free-form + "+2 more" + 1 badge | **CODE-PASS / VISUAL-PARTIAL** | AC2 test: `freeForm.length === 5`, `namespaced.length === 1`. `TagList` math: 5 - 3 = 2 ⇒ "+2 more" rendered. Badge = #166. |
| 3 | Only 2 namespaced tags ⇒ 2 badges, no "+N more" | **CODE-PASS / VISUAL-PARTIAL** | AC3 test: `freeForm.length === 0`, `namespaced.length === 2`. `freeFormTags.length > 0` guard correctly skips `<TagList>` rendering when only namespaced exist. Badges = #166. |
| 4 | Matches REQ-CONTENT-MODEL-03 in PRD (H-F) | **PASS** | Inline JSDoc on helpers + comments on cards cite **PDR-009 § 7 / REQ-CONTENT-MODEL-03**. Public statement of the cap-exclusion requirement (issue body) is satisfied. |
| 5 | No layout regression in existing post cards | **PASS** | Diff is surgical (1 import + 4-line computed block + variable rename in `<TagList>` prop on each card). No styling/markup changes. No current post in `src/content/blog/` uses namespaced tags ⇒ live build is byte-unchanged. Local `npm run test` (183/183), `npm run typecheck` (0 errors), `npm run build` (5 pages OK), `npx prettier --check` clean. CI gates Visual (QA-09) / a11y (QA-08) / touch-targets (QA-07) / Lighthouse (QA-06) / audit (QA-10) will run on this PR. |

## Scope split (transparency)

Per the issue body: _"Namespaced tags render as dedicated badges (W-H scope)."_ This PR delivers the **splitting + cap-exclusion semantic only**; **badge rendering** for the namespaced group is **#166 (W-H)** and currently OPEN.

Until #166 lands, namespaced tags do not render visually on cards — strictly better than the prior state, where `chapter:first-moves` would have appeared as a raw chip and counted against the +N cap. After #166 ships, namespaced badges slot into `.post-card-badges` next to `PillarBadge` / `SeriesBadge`; no further changes to PostCard / PostCardFeatured are needed.

The AC#1-3 wording "+ N badges" therefore describes the integrated end state of #166 + #168. AC#1-3 are **CODE-PASS / VISUAL-PARTIAL** here and become **fully VISUAL-PASS** once #166 merges.

## Notes for orchestrator / Wave 2

- Merge strategy: **rebase-merge** (per `CONTRIBUTING.md`).
- No HQ private files are referenced by content (only by docstring citations to PDR-009 § 7 and REQ-CONTENT-MODEL-03).
- No visual baselines need updating; no audit invariants touch tag-list internals (only `.post-card-summary` text identity, which is unaffected).
- Sister tickets in the PDR-009 schema-evolution slate: #164 ✅ (taxonomy.ts SSoT, prerequisite), #165 (W-G — Zod superRefine on `chapter:*`/`wwh:*` slug values), #166 (W-H — labeled badge components), #167 (W-I — BlogFilter chip label resolution), #169 (W-K — JSON-LD), #170 (W-L — llms.txt grouping). This PR does not block any of them; #166 / #167 will consume `RESERVED_NAMESPACES` and `partitionTags` from this PR's exports.

## Test plan

- [x] `npm run test` locally — 183/183 pass (8 files, 19 new in `taxonomy.test.ts`)
- [x] `npm run typecheck` locally — 0 errors, 0 warnings (2 pre-existing unrelated hints in `eslint.config.js` and `BlogFilter.astro`)
- [x] `npm run build` locally — 5 pages built clean
- [x] `npm run lint` locally — 0 errors, 0 warnings
- [x] `npx prettier --check` on touched files — clean
- [ ] CI: full pipeline (security audit, lint, typecheck, unit tests, build, Playwright QA-07/08/09, QA-10.1/10.2/10.3, QA-10.5, Lighthouse QA-06)
- [ ] Automated reviewer (Copilot) feedback addressed if surfaced

---

References:
- **PDR-009 § 7** "Display rendering" (HDIAI HQ, private — see `CONTRIBUTING.md` § Cross-repo setup)
- **PDR-009 § Implementation Pending item 11** (display-cap exclusion identified as launch-gating)
- HQ PRD **REQ-CONTENT-MODEL-03** (display rule for namespaced tags on post cards)
- Sister: #164 (prerequisite, merged), #166 (W-H badge rendering, OPEN)