### PR TITLE
(chore) run astro check in deploy.yml before astro build per #178

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build with Astro
         uses: withastro/action@v6
 


### PR DESCRIPTION
## Summary

Closes #178. PDR-009 § 7 item 8 (LAUNCH-GATING) literal compliance: `astro check` now runs in `.github/workflows/deploy.yml` before `astro build`.

**Why**: `astro build` alone does NOT re-run content-layer Zod refine validation — only `astro check` (via `npm run typecheck` = `astro sync && astro check`) surfaces refine errors. Before this change, `deploy.yml` used `withastro/action@v6` directly (astro build only) and bypassed `ci.yml`'s typecheck gate (cross-workflow `needs:` is unsupported by GitHub Actions; branch protection on `main` is not enabled). A direct push to main with an invalid namespaced tag (e.g., `chapter:judgement` British-spelling typo, or two `chapter:*` tags on one post) would build green and ship broken filter URLs / wrong JSON-LD `isPartOf`.

**How**: Insert three steps between the existing `Checkout` and `Build with Astro` steps, byte-equivalent to the corresponding pre-build sequence already in `ci.yml`:

```yaml
- name: Setup Node.js
  uses: actions/setup-node@v6
  with:
    node-version: lts/*
    cache: npm

- name: Install dependencies
  run: npm ci

- name: Type check
  run: npm run typecheck
```

Both workflows now enforce the same strictness invariant.

## Acceptance criteria

- [x] **AC #1** — `.github/workflows/deploy.yml` runs `astro check` (via `npm run typecheck`) before any `astro build` invocation. Verified by inspection: `Type check` step precedes `Build with Astro` (`withastro/action@v6`).
- [x] **AC #2** — Failure scenario verified. The literal reading is structurally unverifiable on a feature branch (deploy.yml only triggers on push-to-main + workflow_dispatch, and feature-branch dispatch can't deploy GitHub Pages). The compositional reading is satisfied: `npm run typecheck` resolves identically (`astro sync && astro check`) on local and CI; local logs prove all three PDR-009 § 7 scenarios behave correctly:
  - Scenario 1 (`chapter:judgement` typo): EXIT 1, `tags.4: Unknown chapter slug: "judgement". Valid: first-moves, mental-models, interaction, judgment, workflow, where-you-are, meta-skill`
  - Scenario 2 (two `chapter:*` tags): EXIT 1, `tags: At most one chapter: tag allowed`
  - Scenario 3 (`chapter:judgment` + `wwh:how-to-do`): EXIT 0, 0 errors
- [x] **AC #3** — No regression > +90s typical. Recent baseline `deploy.yml` runs (no typecheck) avg ~47s; +30–60s typecheck addition stays within the +90s budget. (Cold-cache first run may temporarily exceed +90s; AC qualifier "typical" covers steady-state.)
- [x] **AC #4** — No new external dependencies. `git diff origin/main -- package.json package-lock.json` is empty. Both `actions/setup-node@v6` and `actions/checkout@v6` are already used by `ci.yml`; no new GitHub Actions either.

## Test plan

- [x] Baseline `npm run typecheck` on the unmodified branch: 0 errors, 0 warnings.
- [x] PDR-009 Scenario 1 (`chapter:judgement` typo on `sample-post.md`) → typecheck EXIT 1 with refine error (log: `.tmp/tc-scenario1.log`).
- [x] PDR-009 Scenario 2 (two `chapter:*` tags) → typecheck EXIT 1 with cardinality error (log: `.tmp/tc-scenario2.log`).
- [x] PDR-009 Scenario 3 (valid `chapter:judgment` + `wwh:how-to-do`) → typecheck EXIT 0 (log: `.tmp/tc-scenario3.log`).
- [x] Test fixture reverted; final diff is +12 lines in `deploy.yml` only.
- [ ] CI green (existing `ci.yml` checks).
- [ ] Post-merge: first deploy.yml run on main exercises the new typecheck step in production.

## References

- Issue: #178
- PDR-009 § 7 item 8 + § Rationale "Operational requirements for the strictness claim" (HQ `docs/decisions/PDR-009-schema-evolution-principle.md`)
- Companion gate: `ci.yml`'s `Type check` step (#165, already merged)
- Parent tracker: HQ `docs/audit-2026-04-24-followups.md` § TF-007 sub-task #4 (closes on this merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)