### PR TITLE
(chore) bump postcss to 8.5.10 to clear GHSA-qx2v-qp2m-jg93

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "fast-xml-parser": "5.7.1",
         "gray-matter": "4.0.3",
         "node-html-parser": "7.1.0",
-        "postcss": "8.5.8",
+        "postcss": "8.5.10",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1",
         "typescript": "^5.9.3",
@@ -8700,9 +8700,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-xml-parser": "5.7.1",
     "gray-matter": "4.0.3",
     "node-html-parser": "7.1.0",
-    "postcss": "8.5.8",
+    "postcss": "8.5.10",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary

Clears [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (PostCSS XSS via unescaped `</style>` in CSS Stringify Output, moderate severity), published 2026-04-25 against `postcss < 8.5.10`. `ci.yml`'s `npm audit --omit=dev` step (line 32) now exits 1 on every PR until this lands.

`postcss` is exact-pinned in devDependencies. Bumping `8.5.8` → `8.5.10` (patch only) preserves the pin style. Lockfile updates all three resolution paths (root direct, `astro` → `vite`, `eslint-plugin-astro`) to `8.5.10`.

## Verification

- `npm audit --omit=dev` → `found 0 vulnerabilities` (exit 0).
- `npm run typecheck` → 0 errors, 0 warnings (2 pre-existing hints).
- `npm run build` → 5 pages built in 1.30s.
- `npm run lint` → clean.
- `npm ls postcss` → all three resolutions deduped to `8.5.10`.

## Test plan

- [x] Audit clean locally
- [ ] CI green (validates audit + typecheck + lint + tests + build + Playwright + Lighthouse all still pass after bump)

## Unblocks

#179 (and any other in-flight PRs blocked on the same advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)