### PR TITLE
(chore) add dependabot for npm + github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+# Dependabot — https://docs.github.com/code-security/dependabot/dependabot-version-updates
+#
+# Currency without floating "latest". The visual-regression suite pins Playwright to
+# an exact Chromium build (72 baselines + 72 style sidecars) behind a Docker<->npm
+# version-parity gate (tests/visual/DOCKER_IMAGE_TAG + scripts/check-playwright-version-parity.mjs),
+# so an unpinned "latest" would invalidate baselines on an uncontrolled schedule.
+# Instead we stay pinned and let Dependabot propose each bump as a reviewable PR.
+# (Security advisories still open PRs immediately, independent of the weekly cadence.)
+version: 2
+updates:
+  # ── npm: package.json / package-lock.json ──────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 8
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # Playwright family lands in ONE atomic PR. A bump usually changes the bundled
+      # Chromium, so on that PR also: bump tests/visual/DOCKER_IMAGE_TAG to the matching
+      # vX.Y.Z-noble tag and regenerate baselines in that container
+      # (npm run test:visual:update && npm run test:audit:update), then merge when green.
+      playwright:
+        patterns:
+          - "*playwright*"
+      # Everything else: batch minor + patch into one weekly PR to cut review noise.
+      # Majors match no group below -> they arrive as individual PRs for individual review.
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ── GitHub Actions: .github/workflows/*.yml ────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` — automated dependency-update PRs for the `npm` and `github-actions` ecosystems.

## Why

Currency without floating `latest`. The QA-09 visual-regression suite pins Playwright to an exact Chromium build (72 Linux baselines) behind a Docker↔npm parity gate, so an unpinned `latest` would invalidate baselines on an uncontrolled schedule. Instead we stay pinned and let Dependabot propose each bump as a reviewable PR.

This closes the gap that left the repo on `@playwright/test 1.59.1` for ~7 weeks while `1.60.0` — carrying the Node-24 `playwright install` hang fix ([microsoft/playwright#40998](https://github.com/microsoft/playwright/issues/40998)) — was already published.

## Config

- **npm** (weekly, Mon): the Playwright family is grouped into **one atomic PR** so a bump's baseline regeneration + `tests/visual/DOCKER_IMAGE_TAG` bump land together (the regen ritual is written into the file as a comment); other minor/patch updates batch into one weekly PR; majors arrive as individual PRs.
- **github-actions** (weekly): all action bumps grouped.
- Security advisories still open PRs immediately, independent of the weekly cadence.

## Risk

Config-only — touches no rendered page, so the QA-09 visual baselines are unaffected and CI should be green. The config is inert until merged (Dependabot reads it from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
